### PR TITLE
IBX-1589: Fixed & renamed Extension ezplatform_graphql to ibexa_graphql

### DIFF
--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -21,7 +21,7 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        return new TreeBuilder('ezplatform_graphql');
+        return new TreeBuilder(IbexaGraphQLExtension::EXTENSION_NAME);
     }
 }
 

--- a/src/bundle/DependencyInjection/IbexaGraphQLExtension.php
+++ b/src/bundle/DependencyInjection/IbexaGraphQLExtension.php
@@ -21,11 +21,18 @@ use Symfony\Component\Yaml\Yaml;
  */
 class IbexaGraphQLExtension extends Extension implements PrependExtensionInterface
 {
+    public const EXTENSION_NAME = 'ibexa_graphql';
+
     private const SCHEMA_DIR_PATH = '/config/graphql/types';
     private const EZPLATFORM_SCHEMA_DIR_PATH = '/ezplatform';
     private const PACKAGE_DIR_PATH = '/vendor/ibexa/graphql';
     private const PACKAGE_SCHEMA_DIR_PATH = '/src/bundle/Resources/config/graphql';
     private const FIELDS_DEFINITION_FILE_NAME = 'Field.types.yaml';
+
+    public function getAlias(): string
+    {
+        return self::EXTENSION_NAME;
+    }
 
     /**
      * {@inheritdoc}

--- a/src/bundle/IbexaGraphQLBundle.php
+++ b/src/bundle/IbexaGraphQLBundle.php
@@ -7,6 +7,7 @@
 namespace Ibexa\Bundle\GraphQL;
 
 use Ibexa\Bundle\GraphQL\DependencyInjection\Compiler;
+use Ibexa\Bundle\GraphQL\DependencyInjection\IbexaGraphQLExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -20,6 +21,11 @@ class IbexaGraphQLBundle extends Bundle
         $container->addCompilerPass(new Compiler\RichTextInputConvertersPass());
         $container->addCompilerPass(new Compiler\SchemaWorkersPass());
         $container->addCompilerPass(new Compiler\SchemaDomainIteratorsPass());
+    }
+
+    public function getContainerExtension()
+    {
+        return new IbexaGraphQLExtension();
     }
 }
 


### PR DESCRIPTION
 Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1589](https://issues.ibexa.co/browse/IBX-1589)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no, not used

Fixed registering Ibexa GraphQL extension with custom alias `ibexa_graphql` (by default Symfony generated `ibexa_graph_ql`).

Since extension does not provide any configuration, this change is only a formality not affecting the Product in any way.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- ~Provided automated test coverage.~ // full stack Behat coverage
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review