### PR TITLE
IBX-1694: Rebranded dependency injection container service tags

### DIFF
--- a/doc/domain_schema.md
+++ b/doc/domain_schema.md
@@ -130,7 +130,7 @@ Examples:
 
 ### Creating a custom worker
 
-Custom workers can be added to customize the schema based on the content model. A worker implements the `Schema\Worker` interface, and are tagged with `ezplatform_graphql.domain_schema_worker`. They implement two methods:
+Custom workers can be added to customize the schema based on the content model. A worker implements the `Schema\Worker` interface, and are tagged with `ibexa.graphql.domain.schema.worker`. They implement two methods:
 
 - `work` will use the arguments to modify the schema.
 - `canWork` will test the schema and arguments, and say if the worker can run on this data.

--- a/src/bundle/DependencyInjection/Compiler/FieldInputHandlersPass.php
+++ b/src/bundle/DependencyInjection/Compiler/FieldInputHandlersPass.php
@@ -14,6 +14,8 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class FieldInputHandlersPass implements CompilerPassInterface
 {
+    private const FIELD_TYPE_INPUT_HANDLER_TAG = 'ibexa.graphql.field_type.input.handler';
+
     public function process(ContainerBuilder $container)
     {
         if (!$container->has(DomainContentMutationResolver::class)) {
@@ -24,16 +26,21 @@ class FieldInputHandlersPass implements CompilerPassInterface
             return;
         }
 
-        $taggedServices = $container->findTaggedServiceIds('ezplatform_graphql.fieldtype_input_handler');
-
+        $taggedServices = $container->findTaggedServiceIds(self::FIELD_TYPE_INPUT_HANDLER_TAG);
         $handlers = [];
-        foreach ($taggedServices as $id => $tags) {
+        foreach ($taggedServices as $serviceId => $tags) {
             foreach ($tags as $tag) {
                 if (!isset($tag['fieldtype'])) {
-                    throw new \InvalidArgumentException("The ezplatform_graphql.fieldtype_input_handler tag requires a 'fieldtype' property set to the Field Type's identifier");
+                    throw new \LogicException(
+                        sprintf(
+                            'Service "%s" tagged with "%s" service tag needs a "fieldtype" attribute set to the Field Type\'s identifier',
+                            $serviceId,
+                            self::FIELD_TYPE_INPUT_HANDLER_TAG
+                        )
+                    );
                 }
 
-                $handlers[$tag['fieldtype']] = new Reference($id);
+                $handlers[$tag['fieldtype']] = new Reference($serviceId);
             }
         }
 

--- a/src/bundle/DependencyInjection/Compiler/RichTextInputConvertersPass.php
+++ b/src/bundle/DependencyInjection/Compiler/RichTextInputConvertersPass.php
@@ -13,6 +13,8 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class RichTextInputConvertersPass implements CompilerPassInterface
 {
+    private const RICHTEXT_INPUT_CONVERTER_TAG = 'ibexa.graphql.richtext.input.converter';
+
     public function process(ContainerBuilder $container)
     {
         if (!$container->has(RichTextInputHandler::class)) {
@@ -20,16 +22,21 @@ class RichTextInputConvertersPass implements CompilerPassInterface
         }
 
         $definition = $container->findDefinition(RichTextInputHandler::class);
-        $taggedServices = $container->findTaggedServiceIds('ezplatform_graphql.richtext_input_converter');
-
+        $taggedServices = $container->findTaggedServiceIds(self::RICHTEXT_INPUT_CONVERTER_TAG);
         $handlers = [];
-        foreach ($taggedServices as $id => $tags) {
+        foreach ($taggedServices as $serviceId => $tags) {
             foreach ($tags as $tag) {
                 if (!isset($tag['format'])) {
-                    throw new \InvalidArgumentException("The ezplatform_graphql.richtext_input_converter tag requires a 'format' property set to the converted format");
+                    throw new \LogicException(
+                        sprintf(
+                            'Service "%s" tagged with "%s" service tag needs a "format" attribute set to the converted format',
+                            $serviceId,
+                            self::RICHTEXT_INPUT_CONVERTER_TAG
+                        )
+                    );
                 }
 
-                $handlers[$tag['format']] = new Reference($id);
+                $handlers[$tag['format']] = new Reference($serviceId);
             }
         }
 

--- a/src/bundle/DependencyInjection/Compiler/SchemaDomainIteratorsPass.php
+++ b/src/bundle/DependencyInjection/Compiler/SchemaDomainIteratorsPass.php
@@ -22,7 +22,7 @@ class SchemaDomainIteratorsPass implements CompilerPassInterface
         $generatorDefinition = $container->getDefinition(Generator::class);
 
         $iterators = [];
-        foreach ($container->findTaggedServiceIds('ezplatform_graphql.schema_domain_iterator') as $id => $tags) {
+        foreach ($container->findTaggedServiceIds('ibexa.graphql.domain_schema.iterator') as $id => $tags) {
             $iterators[] = new Reference($id);
         }
 

--- a/src/bundle/DependencyInjection/Compiler/SchemaWorkersPass.php
+++ b/src/bundle/DependencyInjection/Compiler/SchemaWorkersPass.php
@@ -22,7 +22,7 @@ class SchemaWorkersPass implements CompilerPassInterface
         $generatorDefinition = $container->getDefinition(Generator::class);
 
         $workers = [];
-        foreach ($container->findTaggedServiceIds('ezplatform_graphql.domain_schema_worker') as $id => $tags) {
+        foreach ($container->findTaggedServiceIds('ibexa.graphql.domain.schema.worker') as $id => $tags) {
             $workers[] = new Reference($id);
         }
 

--- a/src/bundle/Resources/config/services/mutations.yaml
+++ b/src/bundle/Resources/config/services/mutations.yaml
@@ -15,100 +15,100 @@ services:
     arguments:
       $fieldType: '@ezpublish.fieldType.ezauthor'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezauthor' }
+      - { name: ibexa.graphql.field_type.input.handler, fieldtype: 'ezauthor' }
 
   Ibexa\GraphQL\Mutation\InputHandler\FieldType\BinaryFile:
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezbinaryfile' }
+      - { name: ibexa.graphql.field_type.input.handler, fieldtype: 'ezbinaryfile' }
 
   Ibexa\GraphQL\Mutation\InputHandler\FieldType\Boolean:
     class: 'Ibexa\GraphQL\Mutation\InputHandler\FieldType\FromHash'
     arguments:
       $fieldType: '@ezpublish.fieldType.ezboolean'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezboolean' }
+      - { name: ibexa.graphql.field_type.input.handler, fieldtype: 'ezboolean' }
 
   Ibexa\GraphQL\Mutation\InputHandler\FieldType\Country:
     class: 'Ibexa\GraphQL\Mutation\InputHandler\FieldType\FromHash'
     arguments:
       $fieldType: '@ezpublish.fieldType.ezcountry'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezcountry' }
+      - { name: ibexa.graphql.field_type.input.handler, fieldtype: 'ezcountry' }
 
   Ibexa\GraphQL\Mutation\InputHandler\FieldType\Date:
     arguments:
       $fieldType: '@ezpublish.fieldType.ezdate'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezdate' }
+      - { name: ibexa.graphql.field_type.input.handler, fieldtype: 'ezdate' }
 
   Ibexa\GraphQL\Mutation\InputHandler\FieldType\DateAndTime:
     class: 'Ibexa\GraphQL\Mutation\InputHandler\FieldType\Date'
     arguments:
       $fieldType: '@ezpublish.fieldType.ezdatetime'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezdatetime' }
+      - { name: ibexa.graphql.field_type.input.handler, fieldtype: 'ezdatetime' }
 
   Ibexa\GraphQL\Mutation\InputHandler\FieldType\Float:
     class: 'Ibexa\GraphQL\Mutation\InputHandler\FieldType\FromHash'
     arguments:
       $fieldType: '@ezpublish.fieldType.ezfloat'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezfloat' }
+      - { name: ibexa.graphql.field_type.input.handler, fieldtype: 'ezfloat' }
 
   Ibexa\GraphQL\Mutation\InputHandler\FieldType\Email:
     class: 'Ibexa\GraphQL\Mutation\InputHandler\FieldType\FromHash'
     arguments:
       $fieldType: '@ezpublish.fieldType.ezemail'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezemail' }
+      - { name: ibexa.graphql.field_type.input.handler, fieldtype: 'ezemail' }
 
   Ibexa\GraphQL\Mutation\InputHandler\FieldType\Image:
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezimage' }
+      - { name: ibexa.graphql.field_type.input.handler, fieldtype: 'ezimage' }
 
   Ibexa\GraphQL\Mutation\InputHandler\FieldType\Integer:
     class: 'Ibexa\GraphQL\Mutation\InputHandler\FieldType\FromHash'
     arguments:
       $fieldType: '@ezpublish.fieldType.ezinteger'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezinteger' }
+      - { name: ibexa.graphql.field_type.input.handler, fieldtype: 'ezinteger' }
 
   Ibexa\GraphQL\Mutation\InputHandler\FieldType\ISBN:
     class: 'Ibexa\GraphQL\Mutation\InputHandler\FieldType\FromHash'
     arguments:
       $fieldType: '@ezpublish.fieldType.ezisbn'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezisbn' }
+      - { name: ibexa.graphql.field_type.input.handler, fieldtype: 'ezisbn' }
 
   Ibexa\GraphQL\Mutation\InputHandler\FieldType\Keyword:
     class: 'Ibexa\GraphQL\Mutation\InputHandler\FieldType\FromHash'
     arguments:
       $fieldType: '@ezpublish.fieldType.ezkeyword'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezkeyword' }
+      - { name: ibexa.graphql.field_type.input.handler, fieldtype: 'ezkeyword' }
 
   Ibexa\GraphQL\Mutation\InputHandler\FieldType\MapLocation:
     class: 'Ibexa\GraphQL\Mutation\InputHandler\FieldType\FromHash'
     arguments:
       $fieldType: '@ezpublish.fieldType.ezgmaplocation'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezgmaplocation' }
+      - { name: ibexa.graphql.field_type.input.handler, fieldtype: 'ezgmaplocation' }
 
   Ibexa\GraphQL\Mutation\InputHandler\FieldType\Media:
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezmedia' }
+      - { name: ibexa.graphql.field_type.input.handler, fieldtype: 'ezmedia' }
 
   Ibexa\GraphQL\Mutation\InputHandler\FieldType\Relation:
     arguments:
       $fieldType: '@ezpublish.fieldType.ezobjectrelation'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezobjectrelation' }
+      - { name: ibexa.graphql.field_type.input.handler, fieldtype: 'ezobjectrelation' }
 
   Ibexa\GraphQL\Mutation\InputHandler\FieldType\RelationList:
     arguments:
       $fieldType: '@ezpublish.fieldType.ezobjectrelationlist'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezobjectrelationlist' }
+      - { name: ibexa.graphql.field_type.input.handler, fieldtype: 'ezobjectrelationlist' }
 
   Ibexa\GraphQL\Mutation\InputHandler\FieldType\RichText:
     arguments:
@@ -116,44 +116,44 @@ services:
         html: '@Ibexa\GraphQL\Mutation\InputHandler\FieldType\RichText\HtmlRichTextConverter'
         markdown: '@Ibexa\GraphQL\Mutation\InputHandler\FieldType\RichText\MarkdownRichTextConverter'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezrichtext' }
+      - { name: ibexa.graphql.field_type.input.handler, fieldtype: 'ezrichtext' }
 
   Ibexa\GraphQL\Mutation\InputHandler\FieldType\RichText\HtmlRichTextConverter:
     arguments:
       $xhtml5Converter: '@ezrichtext.converter.input.xhtml5'
     tags:
-      - { name: ezplatform_graphql.richtext_input_converter, format: html }
+      - { name: ibexa.graphql.richtext.input.converter, format: html }
 
   Ibexa\GraphQL\Mutation\InputHandler\FieldType\RichText\MarkdownRichTextConverter:
     arguments:
       $xhtml5Converter: '@ezrichtext.converter.input.xhtml5'
     tags:
-      - { name: ezplatform_graphql.richtext_input_converter, format: markdown }
+      - { name: ibexa.graphql.richtext.input.converter, format: markdown }
 
   Ibexa\GraphQL\Mutation\InputHandler\FieldType\Selection:
     class: 'Ibexa\GraphQL\Mutation\InputHandler\FieldType\FromHash'
     arguments:
       $fieldType: '@ezpublish.fieldType.ezselection'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezselection' }
+      - { name: ibexa.graphql.field_type.input.handler, fieldtype: 'ezselection' }
 
   Ibexa\GraphQL\Mutation\InputHandler\FieldType\TextBlock:
     class: 'Ibexa\GraphQL\Mutation\InputHandler\FieldType\FromHash'
     arguments:
       $fieldType: '@ezpublish.fieldType.eztext'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'eztext' }
+      - { name: ibexa.graphql.field_type.input.handler, fieldtype: 'eztext' }
 
   Ibexa\GraphQL\Mutation\InputHandler\FieldType\TextLine:
     class: 'Ibexa\GraphQL\Mutation\InputHandler\FieldType\FromHash'
     arguments:
       $fieldType: '@ezpublish.fieldType.ezstring'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezstring' }
+      - { name: ibexa.graphql.field_type.input.handler, fieldtype: 'ezstring' }
 
   Ibexa\GraphQL\Mutation\InputHandler\FieldType\Url:
     class: 'Ibexa\GraphQL\Mutation\InputHandler\FieldType\FromHash'
     arguments:
       $fieldType: '@ezpublish.fieldType.ezurl'
     tags:
-      - { name: ezplatform_graphql.fieldtype_input_handler, fieldtype: 'ezurl' }
+      - { name: ibexa.graphql.field_type.input.handler, fieldtype: 'ezurl' }

--- a/src/bundle/Resources/config/services/schema.yaml
+++ b/src/bundle/Resources/config/services/schema.yaml
@@ -11,11 +11,11 @@ services:
 
         Ibexa\GraphQL\Schema\Worker:
             tags:
-                - {name: 'ezplatform_graphql.domain_schema_worker'}
+                - {name: ibexa.graphql.domain.schema.worker}
 
         Ibexa\GraphQL\Schema\Domain\Iterator:
             tags:
-                - {name: 'ezplatform_graphql.schema_domain_iterator'}
+                - {name: ibexa.graphql.domain_schema.iterator}
 
     Ibexa\Contracts\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionMapper:
         alias: Ibexa\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition\DefaultFieldDefinitionMapper


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1694](https://issues.ibexa.co/browse/IBX-1694)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes, requires ibexa/compatibility-layer#12

In this Pull Request we rename Ibexa's dependency injection container service tags according to the map provided by ibexa/compatibility-layer#12 as a part of the rebranding process. Backward compatibility for old service tags is provided by ibexa/compatibility-layer#12.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Asked for a review
