### PR TITLE
IBX-1993: Upgrade overblog/graphql-bundle to v0.14

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ibexa/rest": "^4.0@dev",
         "ibexa/fieldtype-richtext": "^4.0@dev",
         "lexik/jwt-authentication-bundle": "^2.8",
-        "overblog/graphql-bundle": "^0.13",
+        "overblog/graphql-bundle": "^0.14",
         "erusev/parsedown": "^1.7",
         "symfony/dependency-injection": "^5.0",
         "symfony/http-kernel": "^5.0",

--- a/spec/Schema/Domain/Content/NameHelperSpec.php
+++ b/spec/Schema/Domain/Content/NameHelperSpec.php
@@ -6,7 +6,6 @@ use Ibexa\Core\Repository\Values\ContentType\ContentTypeGroup;
 use Ibexa\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\GraphQL\Schema\Domain\Content\NameHelper;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class NameHelperSpec extends ObjectBehavior
 {

--- a/spec/Schema/Domain/Content/Worker/ContentType/AddItemOfTypeConnectionToGroupSpec.php
+++ b/spec/Schema/Domain/Content/Worker/ContentType/AddItemOfTypeConnectionToGroupSpec.php
@@ -9,7 +9,6 @@ use spec\Ibexa\GraphQL\Tools\ContentTypeArgument;
 use spec\Ibexa\GraphQL\Tools\ContentTypeGroupArgument;
 use spec\Ibexa\GraphQL\Tools\FieldArgArgument;
 use spec\Ibexa\GraphQL\Tools\FieldArgument;
-use spec\Ibexa\GraphQL\Tools\TypeArgument;
 use Prophecy\Argument;
 
 class AddItemOfTypeConnectionToGroupSpec extends ContentTypeWorkerBehavior

--- a/src/bundle/Resources/config/graphql/DomainContent.types.yaml
+++ b/src/bundle/Resources/config/graphql/DomainContent.types.yaml
@@ -115,15 +115,6 @@ BaseDomainContentType:
                 type: ContentType
                 resolve: "@=value"
 
-DomainContentByIdentifierConnection:
-    type: relay-connection
-    config:
-        connectionFields:
-            sliceSize:
-                type: Int!
-            orderBy:
-                type: String
-
 Thumbnail:
     type: object
     config:

--- a/src/bundle/Resources/config/graphql/Item.types.yaml
+++ b/src/bundle/Resources/config/graphql/Item.types.yaml
@@ -102,12 +102,3 @@ BaseItemType:
             _info:
                 type: ContentType
                 resolve: "@=value"
-
-ItemByIdentifierConnection:
-    type: relay-connection
-    config:
-        connectionFields:
-            sliceSize:
-                type: Int!
-            orderBy:
-                type: String

--- a/src/lib/Schema/Builder/Input/Type.php
+++ b/src/lib/Schema/Builder/Input/Type.php
@@ -24,6 +24,8 @@ class Type extends Input
     public $interfaces = [];
 
     public $nodeType;
+
+    public $connectionFields = [];
 }
 
 class_alias(Type::class, 'EzSystems\EzPlatformGraphQL\Schema\Builder\Input\Type');

--- a/src/lib/Schema/Builder/SchemaBuilder.php
+++ b/src/lib/Schema/Builder/SchemaBuilder.php
@@ -59,6 +59,11 @@ class SchemaBuilder implements SchemaBuilderInterface, LoggerAwareInterface
         if (isset($typeInput->nodeType)) {
             $type['config']['nodeType'] = $typeInput->nodeType;
         }
+
+        if (!empty($typeInput->connectionFields)) {
+            $type['config']['connectionFields'] = $typeInput->connectionFields;
+        }
+
         $this->schema[$typeInput->name] = $type;
     }
 

--- a/src/lib/Schema/Domain/Content/Worker/ContentType/DefineItemConnection.php
+++ b/src/lib/Schema/Domain/Content/Worker/ContentType/DefineItemConnection.php
@@ -20,8 +20,11 @@ class DefineItemConnection extends BaseWorker implements Worker
             $this->connectionTypeName($args),
             'relay-connection',
             [
-                'inherits' => 'DomainContentByIdentifierConnection',
                 'nodeType' => $this->typeName($args),
+                'connectionFields' => [
+                    'sliceSize' => ['type' => 'Int!'],
+                    'orderBy' => ['type' => 'String'],
+                ],
             ]
         ));
     }


### PR DESCRIPTION
JIRA https://issues.ibexa.co/browse/IBX-1993.

This PR aims to bump `overblog/graphql` dependency which offers full support for PHP8. Changes were required to adjust definitions that were lacking `nodeType` configuration key. 