### PR TITLE
IBX-869: Fixed loading of mutations schema

### DIFF
--- a/src/bundle/DependencyInjection/GraphQL/YamlSchemaProvider.php
+++ b/src/bundle/DependencyInjection/GraphQL/YamlSchemaProvider.php
@@ -15,7 +15,7 @@ class YamlSchemaProvider implements SchemaProvider
 {
     public const DXP_SCHEMA_PATH = 'ibexa/';
     public const DXP_SCHEMA_FILE = self::DXP_SCHEMA_PATH . 'Domain.types.yaml';
-    public const DXP_MUTATION_FILE = self::DXP_SCHEMA_PATH . 'DomainContentMutation.types.yaml';
+    public const DXP_MUTATION_FILE = self::DXP_SCHEMA_PATH . 'ItemMutation.types.yaml';
     public const APP_QUERY_SCHEMA_FILE = 'Query.types.yaml';
     public const APP_MUTATION_SCHEMA_FILE = 'Mutation.types.yaml';
 
@@ -57,7 +57,7 @@ class YamlSchemaProvider implements SchemaProvider
         if (file_exists($this->getAppMutationSchemaFile())) {
             return 'Mutation';
         } elseif (file_exists($this->getPlatformMutationSchema())) {
-            return 'DomainContentMutation';
+            return 'ItemMutation';
         } else {
             return null;
         }

--- a/src/bundle/Resources/config/graphql/PlatformMutation.types.yaml
+++ b/src/bundle/Resources/config/graphql/PlatformMutation.types.yaml
@@ -4,7 +4,7 @@ PlatformMutation:
         fields:
             deleteContent:
                 type: DeleteContentPayload
-                resolve: '@=mutation("DeleteDomainContent", [args])'
+                resolve: '@=mutation("DeleteDomainContent", args)'
                 args:
                     id:
                         type: ID
@@ -14,7 +14,7 @@ PlatformMutation:
                         description: "ID of the content item to delete"
             uploadFiles:
                 type: UploadedFilesPayload
-                resolve: '@=mutation("UploadFiles", [args])'
+                resolve: '@=mutation("UploadFiles", args)'
                 args:
                     locationId:
                         type: Int!
@@ -26,7 +26,7 @@ PlatformMutation:
                         description: "The language the content items must be created in"
             createToken:
                 type: CreatedTokenPayload
-                resolve: '@=mutation("CreateToken", [args])'
+                resolve: '@=mutation("CreateToken", args)'
                 args:
                     username:
                         type: String!

--- a/src/lib/Schema/Domain/Content/Worker/ContentType/DefineItemMutation.php
+++ b/src/lib/Schema/Domain/Content/Worker/ContentType/DefineItemMutation.php
@@ -37,7 +37,7 @@ class DefineItemMutation extends BaseWorker implements Worker, Initializer
                 $this->getNameHelper()->itemName($contentType) . '!',
                 [
                     'resolve' => sprintf(
-                        '@=mutation("CreateDomainContent", [args["input"], "%s", args["parentLocationId"], args["language"]])',
+                        '@=mutation("CreateDomainContent", args["input"], "%s", args["parentLocationId"], args["language"])',
                         $contentType->identifier
                     ), ]
             )
@@ -69,7 +69,7 @@ class DefineItemMutation extends BaseWorker implements Worker, Initializer
             new Builder\Input\Field(
                 $this->getUpdateField($contentType),
                 $this->getNameHelper()->itemName($contentType) . '!',
-                ['resolve' => '@=mutation("UpdateDomainContent", [args["input"], args, args["versionNo"], args["language"]])']
+                ['resolve' => '@=mutation("UpdateDomainContent", args["input"], args, args["versionNo"], args["language"])']
             )
         );
 


### PR DESCRIPTION
Question | Answer
-- | --
JIRA issue | https://issues.ibexa.co/browse/IBX-869
Type | bugfix
Target Ibexa DXP version | v4.2.x
BC breaks | maybe (custom mutations may have to be updated in the same way)

The schema mutation type is set by detecting what files were generated. When https://github.com/ezsystems/ezplatform-graphql/pull/90 was merged, `DomainContentMutation.types.yaml` was renamed to `ItemMutation.types.yaml`, but the `YamlSchemaProvider` that searches for the files was not updated.

In addition, in v0.14 of overblog/graphql-bundle, the `mutation` function, used to resolve mutations, has been changed. The arguments are not provided as an array anymore, but as regular function arguments. This is the reason for the [error @mnocon found](https://github.com/ibexa/graphql/pull/27#pullrequestreview-891197235). The behaviour had been changed earlier (in v0.13 as far as I can see) but had a compatibility layer that was removed in v0.14.

Note that the `query` function, that replaces the `resolve` one, has undergone the same change, and we will need to update it as well.