### PR TITLE
IBX-2424: Fixed deprecation leftovers after upgrading `overblog/graphql` to v0.14

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ibexa/rest": "^4.0@dev",
         "ibexa/fieldtype-richtext": "^4.0@dev",
         "lexik/jwt-authentication-bundle": "^2.8",
-        "overblog/graphql-bundle": "^0.14",
+        "overblog/graphql-bundle": "^0.14.2",
         "erusev/parsedown": "^1.7",
         "symfony/dependency-injection": "^5.0",
         "symfony/http-kernel": "^5.0",

--- a/src/lib/Relay/DomainConnectionBuilder.php
+++ b/src/lib/Relay/DomainConnectionBuilder.php
@@ -6,7 +6,7 @@
  */
 namespace Ibexa\GraphQL\Relay;
 
-use Overblog\GraphQLBundle\Relay\Connection\Output\ConnectionBuilder;
+use Overblog\GraphQLBundle\Relay\Connection\ConnectionBuilder;
 
 class DomainConnectionBuilder extends ConnectionBuilder
 {

--- a/src/lib/Relay/PageAwareConnection.php
+++ b/src/lib/Relay/PageAwareConnection.php
@@ -7,16 +7,16 @@
 namespace Ibexa\GraphQL\Relay;
 
 use Overblog\GraphQLBundle\Definition\Argument;
+use Overblog\GraphQLBundle\Relay\Connection\ConnectionBuilder;
 use Overblog\GraphQLBundle\Relay\Connection\Output\Connection;
-use Overblog\GraphQLBundle\Relay\Connection\Output\ConnectionBuilder;
-use Overblog\GraphQLBundle\Relay\Connection\Output\PageInfo;
+use Overblog\GraphQLBundle\Relay\Connection\PageInfoInterface;
 
 final class PageAwareConnection
 {
     /** @var \Overblog\GraphQLBundle\Relay\Connection\Output\Edge[] */
     public $edges = [];
 
-    /** @var \Overblog\GraphQLBundle\Relay\Connection\Output\PageInfo */
+    /** @var \Overblog\GraphQLBundle\Relay\Connection\PageInfoInterface */
     public $pageInfo;
 
     /** @var int */
@@ -25,7 +25,7 @@ final class PageAwareConnection
     /** @var Page[] */
     public $pages;
 
-    public function __construct(array $edges, PageInfo $pageInfo)
+    public function __construct(array $edges, PageInfoInterface $pageInfo)
     {
         $this->edges = $edges;
         $this->pageInfo = $pageInfo;
@@ -40,9 +40,10 @@ final class PageAwareConnection
 
         $perPage = $args['first'] ?? $args['last'] ?? 10;
         $totalPages = ceil($return->totalCount / $perPage);
+        $connectionBuilder = new ConnectionBuilder();
         for ($pageNumber = 2; $pageNumber <= $totalPages; ++$pageNumber) {
             $offset = ($pageNumber - 1) * $perPage - 1;
-            $return->pages[] = new Page($pageNumber, ConnectionBuilder::offsetToCursor($offset));
+            $return->pages[] = new Page($pageNumber, $connectionBuilder->offsetToCursor($offset));
         }
 
         return $return;

--- a/src/lib/Relay/SearchResolver.php
+++ b/src/lib/Relay/SearchResolver.php
@@ -9,7 +9,7 @@ namespace Ibexa\GraphQL\Relay;
 use Ibexa\Contracts\Core\Repository\SearchService;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query;
 use Ibexa\Contracts\Core\Repository\Values\Content\Search\SearchHit;
-use Overblog\GraphQLBundle\Relay\Connection\Output\ConnectionBuilder;
+use Overblog\GraphQLBundle\Relay\Connection\ConnectionBuilder;
 
 class SearchResolver
 {
@@ -60,7 +60,8 @@ class SearchResolver
             $searchResult->searchHits
         );
 
-        $connection = ConnectionBuilder::connectionFromArraySlice(
+        $connectionBuilder = new ConnectionBuilder();
+        $connection = $connectionBuilder->connectionFromArraySlice(
             $contentItems,
             $args,
             [


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-2424

Due to upgrading `overblog/graphql` to 0.14 there are some leftovers related to:
- `ConnectionBuilder` namespace change, ref: https://github.com/overblog/GraphQLBundle/blob/master/UPGRADE.md#remove-connectionbuilder-deprecated-class
- changes to Relay Paginator and setting its properties, ref: https://github.com/overblog/GraphQLBundle/blob/master/UPGRADE.md#relay-paginator-connections--edges 