### PR TITLE
IBX-2467: Added `admin` repository permissions

### DIFF
--- a/src/bundle/Command/GeneratePlatformSchemaCommand.php
+++ b/src/bundle/Command/GeneratePlatformSchemaCommand.php
@@ -7,7 +7,7 @@
 namespace Ibexa\Bundle\GraphQL\Command;
 
 use Ibexa\Bundle\Core\Command\BackwardCompatibleCommand;
-use Ibexa\Core\Repository\Repository;
+use Ibexa\Contracts\Core\Repository\Repository;
 use Ibexa\GraphQL\Schema\Generator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -56,7 +56,7 @@ class GeneratePlatformSchemaCommand extends Command implements BackwardCompatibl
             );
     }
 
-    protected function initialize(InputInterface $input, OutputInterface $output)
+    protected function initialize(InputInterface $input, OutputInterface $output): void
     {
         $this->repository->getPermissionResolver()->setCurrentUserReference(
             $this->repository->getUserService()->loadUserByLogin($input->getOption('user'))

--- a/src/bundle/Command/GeneratePlatformSchemaCommand.php
+++ b/src/bundle/Command/GeneratePlatformSchemaCommand.php
@@ -19,8 +19,6 @@ use Symfony\Component\Yaml\Yaml;
 
 class GeneratePlatformSchemaCommand extends Command implements BackwardCompatibleCommand
 {
-    private const ADMIN_USER_ID = 14;
-
     /**
      * @var \Ibexa\GraphQL\Schema\Generator
      */
@@ -48,13 +46,20 @@ class GeneratePlatformSchemaCommand extends Command implements BackwardCompatibl
             ->setAliases(['ezplatform:graphql:generate-schema'])
             ->setDescription('Generates the GraphQL schema for the Ibexa DXP instance')
             ->addOption('dry-run', null, InputOption::VALUE_OPTIONAL, 'Do not write, output the schema only', false)
-            ->addOption('include', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Type to output or write', []);
+            ->addOption('include', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Type to output or write', [])
+            ->addOption(
+                'user',
+                'u',
+                InputOption::VALUE_REQUIRED,
+                'Ibexa DXP username',
+                'admin'
+            );
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output)
     {
         $this->repository->getPermissionResolver()->setCurrentUserReference(
-            $this->repository->getUserService()->loadUser(self::ADMIN_USER_ID)
+            $this->repository->getUserService()->loadUserByLogin($input->getOption('user'))
         );
     }
 

--- a/src/bundle/Command/GeneratePlatformSchemaCommand.php
+++ b/src/bundle/Command/GeneratePlatformSchemaCommand.php
@@ -7,6 +7,7 @@
 namespace Ibexa\Bundle\GraphQL\Command;
 
 use Ibexa\Bundle\Core\Command\BackwardCompatibleCommand;
+use Ibexa\Core\Repository\Repository;
 use Ibexa\GraphQL\Schema\Generator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -18,20 +19,25 @@ use Symfony\Component\Yaml\Yaml;
 
 class GeneratePlatformSchemaCommand extends Command implements BackwardCompatibleCommand
 {
+    private const ADMIN_USER_ID = 14;
+
     /**
      * @var \Ibexa\GraphQL\Schema\Generator
      */
     private $generator;
+
+    private Repository $repository;
 
     /**
      * @var string
      */
     private $schemaRootDir;
 
-    public function __construct(Generator $generator, string $schemaRootDir)
+    public function __construct(Generator $generator, Repository $repository, string $schemaRootDir)
     {
         parent::__construct();
         $this->generator = $generator;
+        $this->repository = $repository;
         $this->schemaRootDir = $schemaRootDir;
     }
 
@@ -43,6 +49,13 @@ class GeneratePlatformSchemaCommand extends Command implements BackwardCompatibl
             ->setDescription('Generates the GraphQL schema for the Ibexa DXP instance')
             ->addOption('dry-run', null, InputOption::VALUE_OPTIONAL, 'Do not write, output the schema only', false)
             ->addOption('include', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Type to output or write', []);
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output)
+    {
+        $this->repository->getPermissionResolver()->setCurrentUserReference(
+            $this->repository->getUserService()->loadUser(self::ADMIN_USER_ID)
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-2467

>Currently, `ibexa:graphql:generate-schema` command does not set admin permissions by default. This leads to empty results e.g. when utilizing `ProductTypeService::findProductTypes` due to `View` permissions check, ref: https://github.com/ibexa/product-catalog/blob/main/src/lib/Local/Repository/ProductTypeService.php#L305.