### PR TITLE
IBX-2355: Made inheritance of the naming methods possible

### DIFF
--- a/spec/Schema/Domain/Content/NameHelperSpec.php
+++ b/spec/Schema/Domain/Content/NameHelperSpec.php
@@ -5,27 +5,31 @@ namespace spec\Ibexa\GraphQL\Schema\Domain\Content;
 use Ibexa\Core\Repository\Values\ContentType\ContentTypeGroup;
 use Ibexa\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\GraphQL\Schema\Domain\Content\NameHelper;
+use Ibexa\GraphQL\Schema\Domain\Pluralizer;
 use PhpSpec\ObjectBehavior;
 
 class NameHelperSpec extends ObjectBehavior
 {
-    function let()
+    public function let(Pluralizer $pluralizer): void
     {
-        $this->beConstructedWith(['id'=>'id_']);
+        $this->beConstructedWith(
+            ['id'=>'id_'],
+            $pluralizer
+        );
     }
 
-    function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(NameHelper::class);
     }
 
-    function it_removes_special_characters_from_ContentTypeGroup_identifier()
+    public function it_removes_special_characters_from_ContentTypeGroup_identifier(): void
     {
         $contentTypeGroup = new ContentTypeGroup(['identifier' => 'Name with-hyphen']);
         $this->itemGroupName($contentTypeGroup)->shouldBe('ItemGroupNameWithHyphen');
     }
 
-    function it_removes_field_type_identifier_colisions()
+    public function it_removes_field_type_identifier_colisions(): void
     {
         $fieldDefinition = new FieldDefinition(['identifier' => 'id']);
         $this->fieldDefinitionField($fieldDefinition)->shouldBe('id_');

--- a/src/bundle/Resources/config/services/schema.yaml
+++ b/src/bundle/Resources/config/services/schema.yaml
@@ -85,6 +85,8 @@ services:
 
     Ibexa\GraphQL\Schema\Domain\Content\NameHelper: ~
 
+    Ibexa\GraphQL\Schema\Domain\Content\Pluralizer: ~
+
     Ibexa\GraphQL\Schema\Domain\NameValidator:
         calls:
             - method: setLogger

--- a/src/bundle/Resources/config/services/schema.yaml
+++ b/src/bundle/Resources/config/services/schema.yaml
@@ -83,10 +83,6 @@ services:
 
     Ibexa\GraphQL\Schema\Domain\Content\LanguagesIterator: ~
 
-    Ibexa\GraphQL\Schema\Domain\Content\NameHelper: ~
-
-    Ibexa\GraphQL\Schema\Domain\Content\Pluralizer: ~
-
     Ibexa\GraphQL\Schema\Domain\NameValidator:
         calls:
             - method: setLogger
@@ -107,3 +103,16 @@ services:
     Ibexa\GraphQL\Schema\ImagesVariationsBuilder: ~
 
     Ibexa\GraphQL\Schema\SchemaGenerator: ~
+
+    Ibexa\GraphQL\Schema\Domain\Pluralizer: ~
+
+    Ibexa\GraphQL\Schema\Domain\BaseNameHelper:
+        abstract: true
+        arguments:
+            $pluralizer: '@Ibexa\GraphQL\Schema\Domain\Pluralizer'
+
+    Ibexa\GraphQL\Schema\Domain\Content\NameHelper:
+        parent: Ibexa\GraphQL\Schema\Domain\BaseNameHelper
+        arguments:
+            $fieldNameOverrides: '%ibexa.graphql.schema.content.field_name.override%'
+            $pluralizer: '@Ibexa\GraphQL\Schema\Domain\Pluralizer'

--- a/src/bundle/Resources/config/services/services.yaml
+++ b/src/bundle/Resources/config/services/services.yaml
@@ -43,7 +43,3 @@ services:
             $configResolver: '@ibexa.config.resolver'
             $provider: '@ibexa.siteaccess.provider'
             $siteAccessGroups: '%ibexa.site_access.groups%'
-
-    Ibexa\GraphQL\Schema\Domain\Content\NameHelper:
-        arguments:
-            $fieldNameOverrides: '%ibexa.graphql.schema.content.field_name.override%'

--- a/src/lib/Schema/Domain/BaseNameHelper.php
+++ b/src/lib/Schema/Domain/BaseNameHelper.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace Ibexa\GraphQL\Schema\Domain;
 
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;

--- a/src/lib/Schema/Domain/BaseNameHelper.php
+++ b/src/lib/Schema/Domain/BaseNameHelper.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace Ibexa\GraphQL\Schema\Domain;
+
+use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
+
+abstract class BaseNameHelper
+{
+    private CamelCaseToSnakeCaseNameConverter $caseConverter;
+
+    private Pluralizer $pluralizer;
+
+    public function __construct(Pluralizer $pluralizer)
+    {
+        $this->caseConverter = new CamelCaseToSnakeCaseNameConverter(null, false);
+        $this->pluralizer = $pluralizer;
+    }
+
+    protected function toCamelCase(string $string): string
+    {
+        return $this->caseConverter->denormalize($string);
+    }
+
+    protected function pluralize(string $name): string
+    {
+        return $this->pluralizer->pluralize($name);
+    }
+}

--- a/src/lib/Schema/Domain/Content/NameHelper.php
+++ b/src/lib/Schema/Domain/Content/NameHelper.php
@@ -22,18 +22,24 @@ class NameHelper implements LoggerAwareInterface
     /**
      * @var \Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter
      */
-    protected $caseConverter;
+    private $caseConverter;
 
     /**
      * @var string[]
      */
     private $fieldNameOverrides;
 
-    public function __construct(array $fieldNameOverrides, LoggerInterface $logger = null)
-    {
+    private Pluralizer $pluralizer;
+
+    public function __construct(
+        array $fieldNameOverrides,
+        Pluralizer $pluralizer,
+        LoggerInterface $logger = null
+    ) {
         $this->caseConverter = new CamelCaseToSnakeCaseNameConverter(null, false);
         $this->logger = $logger ?? new NullLogger();
         $this->fieldNameOverrides = $fieldNameOverrides;
+        $this->pluralizer = $pluralizer;
     }
 
     /**
@@ -48,7 +54,9 @@ class NameHelper implements LoggerAwareInterface
 
     public function itemConnectionField(ContentType $contentType)
     {
-        return $this->pluralize(lcfirst($this->toCamelCase($contentType->identifier)));
+        return $this->pluralizer->pluralize(
+            lcfirst($this->toCamelCase($contentType->identifier))
+        );
     }
 
     /**
@@ -237,53 +245,9 @@ class NameHelper implements LoggerAwareInterface
         return $fieldName;
     }
 
-    protected function toCamelCase($string)
+    private function toCamelCase($string)
     {
         return $this->caseConverter->denormalize($string);
-    }
-
-    protected function pluralize($name)
-    {
-        if (substr($name, -1) === 'f') {
-            return substr($name, 0, -1) . 'ves';
-        }
-
-        if (substr($name, -1) === 'fe') {
-            return substr($name, 0, -2) . 'ves';
-        }
-
-        if (substr($name, -1) === 'y') {
-            if (\in_array(substr($name, -2, 1), ['a', 'e', 'i', 'o', 'u'])) {
-                return $name . 's';
-            } else {
-                return substr($name, 0, -1) . 'ies';
-            }
-        }
-
-        if (substr($name, -2) === 'is') {
-            return substr($name, 0, -2) . 'es';
-        }
-
-        if (substr($name, -2) === 'us') {
-            return substr($name, 0, -2) . 'i';
-        }
-
-        if (\in_array(substr($name, -2), ['on', 'um'])) {
-            return substr($name, 0, -2) . 'a';
-        }
-
-        if (substr($name, -2) === 'is') {
-            return substr($name, 0, -2) . 'es';
-        }
-
-        if (
-            preg_match('/(s|sh|ch|x|z)$/', $name) ||
-            substr($name, -1) === 'o'
-        ) {
-            return $name . 'es';
-        }
-
-        return $name . 's';
     }
 
     /**

--- a/src/lib/Schema/Domain/Content/NameHelper.php
+++ b/src/lib/Schema/Domain/Content/NameHelper.php
@@ -9,37 +9,31 @@ namespace Ibexa\GraphQL\Schema\Domain\Content;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeGroup;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
+use Ibexa\GraphQL\Schema\Domain\BaseNameHelper;
+use Ibexa\GraphQL\Schema\Domain\Pluralizer;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
 
-class NameHelper implements LoggerAwareInterface
+class NameHelper extends BaseNameHelper implements LoggerAwareInterface
 {
     use LoggerAwareTrait;
 
     /**
-     * @var \Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter
-     */
-    private $caseConverter;
-
-    /**
      * @var string[]
      */
-    private $fieldNameOverrides;
-
-    private Pluralizer $pluralizer;
+    private array $fieldNameOverrides;
 
     public function __construct(
         array $fieldNameOverrides,
         Pluralizer $pluralizer,
         LoggerInterface $logger = null
     ) {
-        $this->caseConverter = new CamelCaseToSnakeCaseNameConverter(null, false);
+        parent::__construct($pluralizer);
+
         $this->logger = $logger ?? new NullLogger();
         $this->fieldNameOverrides = $fieldNameOverrides;
-        $this->pluralizer = $pluralizer;
     }
 
     /**
@@ -54,9 +48,7 @@ class NameHelper implements LoggerAwareInterface
 
     public function itemConnectionField(ContentType $contentType)
     {
-        return $this->pluralizer->pluralize(
-            lcfirst($this->toCamelCase($contentType->identifier))
-        );
+        return $this->pluralize(lcfirst($this->toCamelCase($contentType->identifier)));
     }
 
     /**
@@ -243,11 +235,6 @@ class NameHelper implements LoggerAwareInterface
         }
 
         return $fieldName;
-    }
-
-    private function toCamelCase($string)
-    {
-        return $this->caseConverter->denormalize($string);
     }
 
     /**

--- a/src/lib/Schema/Domain/Content/NameHelper.php
+++ b/src/lib/Schema/Domain/Content/NameHelper.php
@@ -22,7 +22,7 @@ class NameHelper implements LoggerAwareInterface
     /**
      * @var \Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter
      */
-    private $caseConverter;
+    protected $caseConverter;
 
     /**
      * @var string[]
@@ -237,12 +237,12 @@ class NameHelper implements LoggerAwareInterface
         return $fieldName;
     }
 
-    private function toCamelCase($string)
+    protected function toCamelCase($string)
     {
         return $this->caseConverter->denormalize($string);
     }
 
-    private function pluralize($name)
+    protected function pluralize($name)
     {
         if (substr($name, -1) === 'f') {
             return substr($name, 0, -1) . 'ves';

--- a/src/lib/Schema/Domain/Content/NameHelper.php
+++ b/src/lib/Schema/Domain/Content/NameHelper.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace Ibexa\GraphQL\Schema\Domain\Content;
 
 use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;

--- a/src/lib/Schema/Domain/Content/Pluralizer.php
+++ b/src/lib/Schema/Domain/Content/Pluralizer.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace Ibexa\GraphQL\Schema\Domain\Content;
+
+/**
+ * @internal
+ */
+final class Pluralizer
+{
+    public function pluralize(string $name): string
+    {
+        if (substr($name, -1) === 'f') {
+            return substr($name, 0, -1) . 'ves';
+        }
+
+        if (substr($name, -1) === 'fe') {
+            return substr($name, 0, -2) . 'ves';
+        }
+
+        if (substr($name, -1) === 'y') {
+            if (\in_array(substr($name, -2, 1), ['a', 'e', 'i', 'o', 'u'])) {
+                return $name . 's';
+            } else {
+                return substr($name, 0, -1) . 'ies';
+            }
+        }
+
+        if (substr($name, -2) === 'is') {
+            return substr($name, 0, -2) . 'es';
+        }
+
+        if (substr($name, -2) === 'us') {
+            return substr($name, 0, -2) . 'i';
+        }
+
+        if (\in_array(substr($name, -2), ['on', 'um'])) {
+            return substr($name, 0, -2) . 'a';
+        }
+
+        if (substr($name, -2) === 'is') {
+            return substr($name, 0, -2) . 'es';
+        }
+
+        if (
+            preg_match('/(s|sh|ch|x|z)$/', $name) ||
+            substr($name, -1) === 'o'
+        ) {
+            return $name . 'es';
+        }
+
+        return $name . 's';
+    }
+}

--- a/src/lib/Schema/Domain/Pluralizer.php
+++ b/src/lib/Schema/Domain/Pluralizer.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace Ibexa\GraphQL\Schema\Domain;
 
 /**

--- a/src/lib/Schema/Domain/Pluralizer.php
+++ b/src/lib/Schema/Domain/Pluralizer.php
@@ -4,12 +4,12 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace Ibexa\GraphQL\Schema\Domain\Content;
+namespace Ibexa\GraphQL\Schema\Domain;
 
 /**
  * @internal
  */
-final class Pluralizer
+class Pluralizer
 {
     public function pluralize(string $name): string
     {


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-2355

In order to reuse methods `pluralize` and `toCamelCase` within https://github.com/ibexa/product-catalog/pull/456 we need to change their scope to be able to decorate the original implementation and avoid redundancy.