### PR TITLE
Fixed deprecated NameHelper::domain* method usages

### DIFF
--- a/spec/Schema/Domain/Content/Worker/ContentTypeGroup/AddDomainGroupToDomainSpec.php
+++ b/spec/Schema/Domain/Content/Worker/ContentTypeGroup/AddDomainGroupToDomainSpec.php
@@ -22,11 +22,11 @@ class AddDomainGroupToDomainSpec extends ContentTypeGroupWorkerBehavior
         $this->setNameHelper($nameHelper);
 
         $nameHelper
-            ->domainGroupName(Argument::type(ContentTypeGroup::class))
+            ->itemGroupName(Argument::type(ContentTypeGroup::class))
             ->willReturn(self::GROUP_TYPE);
 
         $nameHelper
-            ->domainGroupField(Argument::type(ContentTypeGroup::class))
+            ->itemGroupField(Argument::type(ContentTypeGroup::class))
             ->willReturn(self::GROUP_FIELD);
     }
 

--- a/spec/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroupSpec.php
+++ b/spec/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroupSpec.php
@@ -22,11 +22,11 @@ class DefineDomainGroupSpec extends ContentTypeGroupWorkerBehavior
         $this->setNameHelper($nameHelper);
 
         $nameHelper
-            ->domainGroupName(Argument::type(ContentTypeGroup::class))
+            ->itemGroupName(Argument::type(ContentTypeGroup::class))
             ->willReturn(self::GROUP_TYPE);
 
         $nameHelper
-            ->domainGroupTypesName(Argument::type(ContentTypeGroup::class))
+            ->itemGroupTypesName(Argument::type(ContentTypeGroup::class))
             ->willReturn(self::GROUP_TYPES_TYPE);
     }
 

--- a/spec/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroupTypesSpec.php
+++ b/spec/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroupTypesSpec.php
@@ -20,7 +20,7 @@ class DefineDomainGroupTypesSpec extends ContentTypeGroupWorkerBehavior
         $this->setNameHelper($nameHelper);
 
         $nameHelper
-            ->domainGroupTypesName(Argument::type(ContentTypeGroup::class))
+            ->itemGroupTypesName(Argument::type(ContentTypeGroup::class))
             ->willReturn(self::GROUP_TYPES_TYPE);
     }
 

--- a/src/lib/Relay/NodeResolver.php
+++ b/src/lib/Relay/NodeResolver.php
@@ -71,7 +71,7 @@ class NodeResolver
     {
         if ($object instanceof ContentInfo) {
             return $this->typeResolver->resolve(
-                $this->nameHelper->domainContentName(
+                $this->nameHelper->itemName(
                     $this->contentTypeService->loadContentType($object->contentTypeId)
                 )
             );

--- a/src/lib/Schema/Domain/Content/NameHelper.php
+++ b/src/lib/Schema/Domain/Content/NameHelper.php
@@ -58,7 +58,7 @@ class NameHelper implements LoggerAwareInterface
     {
         @trigger_error('Deprecated since v3.0, will be removed in v4.0. Use itemName() instead.', E_USER_DEPRECATED);
 
-        return $this->domainItemName($contentType);
+        return $this->itemName($contentType);
     }
 
     public function itemName(ContentType $contentType)
@@ -151,7 +151,7 @@ class NameHelper implements LoggerAwareInterface
 
     public function itemMutationCreateItemField(ContentType $contentType)
     {
-        return 'create' . ucfirst($this->domainContentField($contentType));
+        return 'create' . ucfirst($this->itemField($contentType));
     }
 
     /**

--- a/src/lib/Schema/Domain/Content/Worker/ContentTypeGroup/AddDomainGroupToDomain.php
+++ b/src/lib/Schema/Domain/Content/Worker/ContentTypeGroup/AddDomainGroupToDomain.php
@@ -52,12 +52,12 @@ final class AddDomainGroupToDomain extends BaseWorker implements Worker
 
     private function fieldName($args): string
     {
-        return $this->getNameHelper()->domainGroupField($args['ContentTypeGroup']);
+        return $this->getNameHelper()->itemGroupField($args['ContentTypeGroup']);
     }
 
     private function typeGroupName($args): string
     {
-        return $this->getNameHelper()->domainGroupName($args['ContentTypeGroup']);
+        return $this->getNameHelper()->itemGroupName($args['ContentTypeGroup']);
     }
 }
 

--- a/src/lib/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroup.php
+++ b/src/lib/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroup.php
@@ -54,12 +54,12 @@ class DefineDomainGroup extends BaseWorker implements Worker
 
     protected function typeName($args): string
     {
-        return $this->getNameHelper()->domainGroupName($args['ContentTypeGroup']);
+        return $this->getNameHelper()->itemGroupName($args['ContentTypeGroup']);
     }
 
     private function groupTypesName(array $args): string
     {
-        return $this->getNameHelper()->domainGroupTypesName($args['ContentTypeGroup']);
+        return $this->getNameHelper()->itemGroupTypesName($args['ContentTypeGroup']);
     }
 }
 

--- a/src/lib/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroupTypes.php
+++ b/src/lib/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroupTypes.php
@@ -44,7 +44,7 @@ class DefineDomainGroupTypes extends BaseWorker implements Worker
 
     private function typeName($args): string
     {
-        return $this->getNameHelper()->domainGroupTypesName($args['ContentTypeGroup']);
+        return $this->getNameHelper()->itemGroupTypesName($args['ContentTypeGroup']);
     }
 }
 


### PR DESCRIPTION
> JIRA: -

### Description

Fixed deprecated \Ibexa\GraphQL\Schema\Domain\Content\NameHelper::domain* method usages