### PR TITLE
IBX-2899: Rebranded schema storage directory to `/config/graphql/types/ibexa`

### DIFF
--- a/src/bundle/DependencyInjection/GraphQL/YamlSchemaProvider.php
+++ b/src/bundle/DependencyInjection/GraphQL/YamlSchemaProvider.php
@@ -13,9 +13,9 @@ use Ibexa\GraphQL\Resolver\Map\UploadMap;
  */
 class YamlSchemaProvider implements SchemaProvider
 {
-    public const PLATFORM_SCHEMA_PATH = 'ezplatform/';
-    public const PLATFORM_SCHEMA_FILE = self::PLATFORM_SCHEMA_PATH . 'Domain.types.yaml';
-    public const PLATFORM_MUTATION_FILE = self::PLATFORM_SCHEMA_PATH . 'DomainContentMutation.types.yaml';
+    public const DXP_SCHEMA_PATH = 'ibexa/';
+    public const DXP_SCHEMA_FILE = self::DXP_SCHEMA_PATH . 'Domain.types.yaml';
+    public const DXP_MUTATION_FILE = self::DXP_SCHEMA_PATH . 'DomainContentMutation.types.yaml';
     public const APP_QUERY_SCHEMA_FILE = 'Query.types.yaml';
     public const APP_MUTATION_SCHEMA_FILE = 'Mutation.types.yaml';
 
@@ -75,12 +75,12 @@ class YamlSchemaProvider implements SchemaProvider
 
     private function getPlatformQuerySchema()
     {
-        return $this->root . self::PLATFORM_SCHEMA_FILE;
+        return $this->root . self::DXP_SCHEMA_FILE;
     }
 
     private function getPlatformMutationSchema()
     {
-        return $this->root . self::PLATFORM_MUTATION_FILE;
+        return $this->root . self::DXP_MUTATION_FILE;
     }
 }
 

--- a/src/bundle/DependencyInjection/IbexaGraphQLExtension.php
+++ b/src/bundle/DependencyInjection/IbexaGraphQLExtension.php
@@ -24,7 +24,7 @@ class IbexaGraphQLExtension extends Extension implements PrependExtensionInterfa
     public const EXTENSION_NAME = 'ibexa_graphql';
 
     private const SCHEMA_DIR_PATH = '/config/graphql/types';
-    private const EZPLATFORM_SCHEMA_DIR_PATH = '/ezplatform';
+    private const IBEXA_SCHEMA_DIR_PATH = '/ibexa';
     private const PACKAGE_DIR_PATH = '/vendor/ibexa/graphql';
     private const PACKAGE_SCHEMA_DIR_PATH = '/src/bundle/Resources/config/graphql';
     private const FIELDS_DEFINITION_FILE_NAME = 'Field.types.yaml';
@@ -91,12 +91,12 @@ class IbexaGraphQLExtension extends Extension implements PrependExtensionInterfa
         $rootDir = rtrim($container->getParameter('kernel.project_dir'), '/');
 
         $appSchemaDir = $rootDir . self::SCHEMA_DIR_PATH;
-        $eZPlatformSchemaDir = $appSchemaDir . self::EZPLATFORM_SCHEMA_DIR_PATH;
+        $ibexaSchemaDir = $appSchemaDir . self::IBEXA_SCHEMA_DIR_PATH;
         $packageRootDir = $rootDir . self::PACKAGE_DIR_PATH;
         $fieldsDefinitionFile = $packageRootDir . self::PACKAGE_SCHEMA_DIR_PATH . \DIRECTORY_SEPARATOR . self::FIELDS_DEFINITION_FILE_NAME;
 
         $container->setParameter('ibexa.graphql.schema.root_dir', $appSchemaDir);
-        $container->setParameter('ibexa.graphql.schema.ibexa_dir', $eZPlatformSchemaDir);
+        $container->setParameter('ibexa.graphql.schema.ibexa_dir', $ibexaSchemaDir);
         $container->setParameter('ibexa.graphql.schema.fields_definition_file', $fieldsDefinitionFile);
         $container->setParameter('ibexa.graphql.package.root_dir', $packageRootDir);
     }


### PR DESCRIPTION
JIRA ticket: https://issues.ibexa.co/browse/IBX-2899

**Followup PR for Platform.sh**: https://github.com/ibexa/post-install/pull/43

JIRA excerpt:
>There is a leftover in form of the not yet rebranded `config/graphql/types/ezplatform` folder where the schema is stored. It should be just changed to `config/graphql/types/ibexa`.

This change should be also reflected in the documentation, ref: https://doc.ibexa.co/en/latest/api/graphql/#setup.