### PR TITLE
IBX-4929: Fix phpDoc

### DIFF
--- a/src/lib/Mapper/ContentImageAssetMapperStrategy.php
+++ b/src/lib/Mapper/ContentImageAssetMapperStrategy.php
@@ -32,7 +32,7 @@ final class ContentImageAssetMapperStrategy implements ImageAssetMapperStrategyI
 
     /**
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
-     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException|
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
      */
     public function process(ImageAsset\Value $value): Field

--- a/src/lib/Value/ContentFieldValue.php
+++ b/src/lib/Value/ContentFieldValue.php
@@ -17,7 +17,6 @@ use Ibexa\Contracts\Core\Repository\Values\ValueObject;
  * @property int $contentTypeId
  * @property string $fieldDefIdentifier
  * @property object $value
- *
  */
 class ContentFieldValue extends ValueObject
 {

--- a/src/lib/Value/ContentFieldValue.php
+++ b/src/lib/Value/ContentFieldValue.php
@@ -18,7 +18,6 @@ use Ibexa\Contracts\Core\Repository\Values\ValueObject;
  * @property string $fieldDefIdentifier
  * @property object $value
  *
- * @
  */
 class ContentFieldValue extends ValueObject
 {


### PR DESCRIPTION
From phpDocumentor v3.3.1:
* `Unable to parse file "vendor/ibexa/graphql/src/lib/Mapper/ContentImageAssetMapperStrategy.php", an error was detected: A type is missing after a type separator`
* `Unable to parse file "vendor/ibexa/graphql/src/lib/Value/ContentFieldValue.php", an error was detected: The tag "@" does not seem to be wellformed, please check it for errors`