### PR TITLE
IBX-6602: Used Content::getThumbnail directly for obtaining thumbnails

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,6 @@
         "ibexa/http-cache": "~4.5.0@dev",
         "overblog/graphiql-bundle": "^0.2",
         "phpspec/phpspec": "^7.1",
-        "friendsofphp/php-cs-fixer": "^3.0",
         "ibexa/code-style": "~1.2.0",
         "mikey179/vfsstream": "^1.6"
     },

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "overblog/graphiql-bundle": "^0.2",
         "phpspec/phpspec": "^7.1",
         "friendsofphp/php-cs-fixer": "^3.0",
-        "ibexa/code-style": "^1.0",
+        "ibexa/code-style": "~1.2.0",
         "mikey179/vfsstream": "^1.6"
     },
     "autoload": {

--- a/src/bundle/Resources/config/graphql/ContentType.types.yaml
+++ b/src/bundle/Resources/config/graphql/ContentType.types.yaml
@@ -107,7 +107,7 @@ ContentTypeGroup:
                 resolve: "@=resolver('UserById', [value.modifierId])"
             contentTypes:
                 type: "[ContentType]"
-                resolve: "@=resolver('ContentTypesFromGroup', [{'groupId': value.id}])"
+                resolve: "@=query('ContentTypesFromGroup', {'groupId': value.id})"
             groups:
                 type: "[ContentTypeGroup]"
 

--- a/src/bundle/Resources/config/graphql/ContentType.types.yaml
+++ b/src/bundle/Resources/config/graphql/ContentType.types.yaml
@@ -107,7 +107,7 @@ ContentTypeGroup:
                 resolve: "@=resolver('UserById', [value.modifierId])"
             contentTypes:
                 type: "[ContentType]"
-                resolve: "@=resolver('ContentTypesFromGroup', {'groupId': value.id})"
+                resolve: "@=resolver('ContentTypesFromGroup', [{'groupId': value.id}])"
             groups:
                 type: "[ContentTypeGroup]"
 

--- a/src/bundle/Resources/config/graphql/DomainContent.types.yaml
+++ b/src/bundle/Resources/config/graphql/DomainContent.types.yaml
@@ -72,7 +72,7 @@ AbstractDomainContent:
                 resolve: "@=resolver('MainUrlAlias', [value])"
             _thumbnail:
                 type: Thumbnail
-                resolve: "@=resolver('Thumbnail', [value.getThumbnail()])"
+                resolve: "@=query('Thumbnail', value.getThumbnail())"
 
 UntypedContent:
     type: object

--- a/src/bundle/Resources/config/graphql/DomainContent.types.yaml
+++ b/src/bundle/Resources/config/graphql/DomainContent.types.yaml
@@ -72,7 +72,7 @@ AbstractDomainContent:
                 resolve: "@=resolver('MainUrlAlias', [value])"
             _thumbnail:
                 type: Thumbnail
-                resolve: "@=resolver('ContentThumbnail', [value])"
+                resolve: "@=resolver('Thumbnail', [value.getThumbnail()])"
 
 UntypedContent:
     type: object

--- a/src/bundle/Resources/config/graphql/Item.types.yaml
+++ b/src/bundle/Resources/config/graphql/Item.types.yaml
@@ -60,7 +60,7 @@ AbstractItem:
                 resolve: "@=resolver('ItemUrlAlias', [value])"
             _thumbnail:
                 type: Thumbnail
-                resolve: "@=resolver('Thumbnail', [value.getContent().getThumbnail()])"
+                resolve: "@=query('Thumbnail', value.getContent().getThumbnail())"
 
 UntypedItem:
     type: object

--- a/src/bundle/Resources/config/graphql/Item.types.yaml
+++ b/src/bundle/Resources/config/graphql/Item.types.yaml
@@ -60,7 +60,7 @@ AbstractItem:
                 resolve: "@=resolver('ItemUrlAlias', [value])"
             _thumbnail:
                 type: Thumbnail
-                resolve: "@=resolver('ContentThumbnail', [value.getContent()])"
+                resolve: "@=resolver('Thumbnail', [value.getContent().getThumbnail()])"
 
 UntypedItem:
     type: object

--- a/src/bundle/Resources/config/graphql/User.types.yaml
+++ b/src/bundle/Resources/config/graphql/User.types.yaml
@@ -11,7 +11,7 @@ User:
                 resolve: "@=value.contentInfo.name"
             content:
                 type: "UserItem"
-                resolve: "@=value"
+                resolve: "@=resolver('Item', [{id: value.id}])"
             version:
                 type: "Version"
                 description: "Current version metadata"
@@ -23,6 +23,9 @@ User:
             groups:
                 type: "[UserGroup]"
                 resolve: "@=resolver('UserGroupsByUserId', [value.id])"
+            thumbnail:
+                type: Thumbnail
+                resolve: "@=resolver('Thumbnail', [value.getThumbnail()])"
 
 UserGroup:
     type: object

--- a/src/bundle/Resources/config/graphql/User.types.yaml
+++ b/src/bundle/Resources/config/graphql/User.types.yaml
@@ -38,9 +38,9 @@ UserGroup:
                 type: "String"
                 resolve: "@=value.contentInfo.name"
             content:
-                description: "The User content item"
+                description: "The User Group content item"
                 type: "UserGroupItem"
-                resolve: "@=value"
+                resolve: "@=resolver('Item', [{id: value.id}])"
             version:
                 type: "Version"
                 description: "Current version"

--- a/src/bundle/Resources/config/graphql/User.types.yaml
+++ b/src/bundle/Resources/config/graphql/User.types.yaml
@@ -11,7 +11,7 @@ User:
                 resolve: "@=value.contentInfo.name"
             content:
                 type: "UserItem"
-                resolve: "@=resolver('Item', [{id: value.id}])"
+                resolve: "@=query('Item', {id: value.id})"
             version:
                 type: "Version"
                 description: "Current version metadata"
@@ -25,7 +25,7 @@ User:
                 resolve: "@=resolver('UserGroupsByUserId', [value.id])"
             thumbnail:
                 type: Thumbnail
-                resolve: "@=resolver('Thumbnail', [value.getThumbnail()])"
+                resolve: "@=query('Thumbnail', value.getThumbnail())"
 
 UserGroup:
     type: object
@@ -40,7 +40,7 @@ UserGroup:
             content:
                 description: "The User Group content item"
                 type: "UserGroupItem"
-                resolve: "@=resolver('Item', [{id: value.id}])"
+                resolve: "@=query('Item', {id: value.id})"
             version:
                 type: "Version"
                 description: "Current version"

--- a/src/bundle/Resources/config/services/resolvers.yaml
+++ b/src/bundle/Resources/config/services/resolvers.yaml
@@ -58,6 +58,10 @@ services:
         arguments:
             $thumbnailStrategy: '@Ibexa\Core\Repository\Strategy\ContentThumbnail\ThumbnailChainStrategy'
 
+    Ibexa\GraphQL\Resolver\ThumbnailResolver:
+        tags:
+            - { name: overblog_graphql.resolver, alias: "Thumbnail", method: "resolveThumbnail" }
+
     Ibexa\GraphQL\Mutation\Authentication:
         arguments:
             $authenticator: '@?ibexa.rest.session_authenticator'

--- a/src/lib/Resolver/ThumbnailResolver.php
+++ b/src/lib/Resolver/ThumbnailResolver.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace Ibexa\GraphQL\Resolver;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Thumbnail;

--- a/src/lib/Resolver/ThumbnailResolver.php
+++ b/src/lib/Resolver/ThumbnailResolver.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace Ibexa\GraphQL\Resolver;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\Thumbnail;
+
+final class ThumbnailResolver
+{
+    /**
+     * @return array|null array with the thumbnail info, or null if no thumbnail could be obtained for that image
+     */
+    public function resolveThumbnail(?Thumbnail $thumbnail): ?array
+    {
+        if ($thumbnail === null) {
+            return null;
+        }
+
+        return [
+            'uri' => $thumbnail->resource,
+            'width' => $thumbnail->width,
+            'height' => $thumbnail->height,
+            'mimeType' => $thumbnail->mimeType,
+            'alternativeText' => '',
+        ];
+    }
+}


### PR DESCRIPTION
https://issues.ibexa.co/browse/IBX-6602

### Dropped `ContentThumbnail` resolver usage
There is no need for it, as thumbnails can be obtained directly from Content::getThumbnail or User::getThumbnail.
Done this way, instead of doing user.getContent(), as accessing `content` from user object is deprecated.

### Fixed UserItem (and UserGroupItem)
As it had `type: "UserItem"` but it was resolved to `value` it was not UserItem, but actual User object.

### Added Thumbnail for user object

As it is possible now, to obtain thumbnails by accessing content on user object like this:
```graphql
{
  content {
    folder(contentId: 81) {
      _contentInfo {
        owner {
          id
          content {
            _thumbnail {
              uri
            }
          }
        }
      }
    }
  }
}

```
accessing content on user is deprecated (since 6,10 ;) ), so new property was added to match php API
```graphql
{
  content {
     folder (contentId: 81) {
       id,
      _contentInfo {
        owner{
          thumbnail {
            uri,
          },
        }
      }
     }
  }
}
```

### Fixed unpacking object to array:
`resolve: "@=resolver('ContentTypesFromGroup', {'groupId': value.id})"`

This was just not working, and can be tested with 
```graphql
{
_repository {
    contentTypes {
      groups {
        contentTypes {
          name
        }
      }
    }
  }
}  
```
