### PR TITLE
IBX-7979: Fixed "field" occurrences being wrongly replaced

### DIFF
--- a/src/lib/Schema/Domain/Content/Mapper/FieldDefinition/ResolverVariables.php
+++ b/src/lib/Schema/Domain/Content/Mapper/FieldDefinition/ResolverVariables.php
@@ -39,18 +39,25 @@ class ResolverVariables implements FieldDefinitionMapper
     {
         $resolver = $this->innerMapper->mapToFieldValueResolver($fieldDefinition);
 
+        //making sure we won't be replacing "field" occurrences in the actual field's name
+        if (preg_match('/"(.*field.*)"/', $resolver) !== 1) {
+            return str_replace(
+                'field',
+                'resolver("ItemFieldValue", [value, "' . $fieldDefinition->identifier . '", args])',
+                $resolver
+            );
+        }
+
         return str_replace(
             [
                 'content',
                 'location',
                 'item',
-                'field',
             ],
             [
                 'value.getContent()',
                 'value.getLocation()',
                 'value',
-                'resolver("ItemFieldValue", [value, "' . $fieldDefinition->identifier . '", args])',
             ],
             $resolver
         );


### PR DESCRIPTION
https://issues.ibexa.co/browse/IBX-7979

Performing simple `str_replace` on fieldtypes' identifiers like `my_custom_field` instead of
```
'@=resolver("MatrixFieldValue", [value, "my_custom_field"])'
```
produced something like:
```
@=resolver("MatrixFieldValue", [value, "my_custom_resolver("ItemFieldValue", [value, "' . $fieldDefinition->identifier . '", args])"])
```
which is obviously an invalid schema entry.

Decided to just narrow down the actual replacing to values **not being inside double quotes**. The reason for that is that we have several scenarios to be handled like `[field]`, `@=field`, `"@=resolver("Page", [field, context])"` etc. where current `str_replace` needs to be invoked. 