### PR TITLE
IBX-7979: Fixed "field" keyword occurrences in fields' identifiers being wrongly replaced

### DIFF
--- a/src/lib/Schema/Domain/Content/Mapper/FieldDefinition/ResolverVariables.php
+++ b/src/lib/Schema/Domain/Content/Mapper/FieldDefinition/ResolverVariables.php
@@ -39,18 +39,27 @@ class ResolverVariables implements FieldDefinitionMapper
     {
         $resolver = $this->innerMapper->mapToFieldValueResolver($fieldDefinition);
 
+        //we make sure no "field" (case insensitive) keyword in the actual field's identifier gets replaced
+        //only syntax like: '@=resolver("MatrixFieldValue", [value, "field_matrix"])' needs to be taken into account
+        //where [value, "field_matrix"] stands for the actual field's identifier
+        if (preg_match('/value, "(.*field.*)"/i', $resolver) !== 1) {
+            $resolver = str_replace(
+                'field',
+                'resolver("ItemFieldValue", [value, "' . $fieldDefinition->identifier . '", args])',
+                $resolver
+            );
+        }
+
         return str_replace(
             [
                 'content',
                 'location',
                 'item',
-                'field',
             ],
             [
                 'value.getContent()',
                 'value.getLocation()',
                 'value',
-                'resolver("ItemFieldValue", [value, "' . $fieldDefinition->identifier . '", args])',
             ],
             $resolver
         );


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-7979

Followup for https://github.com/ibexa/graphql/pull/59 where `return` was performed too early. I added also some more strict regular expression targeting only actual usage of `field` keyword within fields' identifiers with case-insensitivity taken into account.