### PR TITLE
IBX-8119: Upgraded minimum PHP version to 8.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,13 +10,13 @@ on:
 jobs:
     cs-fix:
         name: Run code style check
-        runs-on: "ubuntu-20.04"
+        runs-on: "ubuntu-22.04"
         strategy:
             matrix:
                 php:
-                    - '8.0'
+                    - '8.3'
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
 
             - name: Setup PHP Action
               uses: shivammathur/setup-php@v2
@@ -26,31 +26,26 @@ jobs:
                   extensions: 'pdo_sqlite, gd'
                   tools: cs2pr
 
-            - uses: "ramsey/composer-install@v1"
+            - uses: ramsey/composer-install@v3
               with:
-                  dependency-versions: "highest"
+                  dependency-versions: highest
 
             - name: Run code style check
               run: composer run-script check-cs -- --format=checkstyle | cs2pr
 
     tests:
         name: Unit tests
-        runs-on: "ubuntu-20.04"
+        runs-on: "ubuntu-22.04"
         timeout-minutes: 15
 
         strategy:
             fail-fast: false
             matrix:
                 php:
-                    - '7.4'
-                    - '8.0'
-                composer_options: [ "" ]
-                include:
-                    - php: '8.1'
-                      composer_options: "--ignore-platform-req php"
+                    - '8.3'
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
 
             - name: Setup PHP Action
               uses: shivammathur/setup-php@v2
@@ -60,10 +55,9 @@ jobs:
                   extensions: pdo_sqlite, gd
                   tools: cs2pr
 
-            - uses: "ramsey/composer-install@v1"
+            - uses: ramsey/composer-install@v3
               with:
-                  dependency-versions: "highest"
-                  composer-options: "${{ matrix.composer_options }}"
+                  dependency-versions: highest
 
             - name: Setup problem matchers for PHPUnit
               run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"

--- a/composer.json
+++ b/composer.json
@@ -14,36 +14,36 @@
         "bdunogier/ezplatform-graphql-bundle": "self.version"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": " >=8.3",
         "ext-dom": "*",
-        "ibexa/core": "~5.0.0@dev",
-        "ibexa/admin-ui": "~5.0.0@dev",
-        "ibexa/rest": "~5.0.0@dev",
-        "ibexa/fieldtype-richtext": "~5.0.0@dev",
+        "erusev/parsedown": "^1.7",
+        "ibexa/admin-ui": "~5.0.x-dev",
+        "ibexa/core": "~5.0.x-dev",
+        "ibexa/fieldtype-richtext": "~5.0.x-dev",
+        "ibexa/rest": "~5.0.x-dev",
         "lexik/jwt-authentication-bundle": "^2.8",
         "overblog/graphql-bundle": "^0.14.2",
-        "erusev/parsedown": "^1.7",
-        "symfony/dependency-injection": "^5.0",
-        "symfony/http-kernel": "^5.0",
-        "symfony/console": "^5.0",
-        "symfony/filesystem": "^5.0",
-        "symfony/yaml": "^5.0",
         "symfony/config": "^5.0",
+        "symfony/console": "^5.0",
+        "symfony/dependency-injection": "^5.0",
+        "symfony/filesystem": "^5.0",
         "symfony/http-foundation": "^5.0",
-        "symfony/serializer": "^5.0"
+        "symfony/http-kernel": "^5.0",
+        "symfony/serializer": "^5.0",
+        "symfony/yaml": "^5.0"
     },
     "require-dev": {
-        "ibexa/doctrine-schema": "~5.0.0@dev",
-        "ibexa/content-forms": "~5.0.0@dev",
-        "ibexa/design-engine": "~5.0.0@dev",
-        "ibexa/user": "~5.0.0@dev",
-        "ibexa/search": "~5.0.0@dev",
-        "ibexa/http-cache": "~5.0.0@dev",
-        "ibexa/notifications": "~5.0.0@dev",
-        "overblog/graphiql-bundle": "^0.2",
-        "phpspec/phpspec": "^7.1",
         "ibexa/code-style": "~1.2.0",
-        "mikey179/vfsstream": "^1.6"
+        "ibexa/content-forms": "~5.0.x-dev",
+        "ibexa/design-engine": "~5.0.x-dev",
+        "ibexa/doctrine-schema": "~5.0.x-dev",
+        "ibexa/http-cache": "~5.0.x-dev",
+        "ibexa/notifications": "~5.0.x-dev",
+        "ibexa/search": "~5.0.x-dev",
+        "ibexa/user": "~5.0.x-dev",
+        "mikey179/vfsstream": "^1.6",
+        "overblog/graphiql-bundle": "^0.2",
+        "phpspec/phpspec": "^7.1"
     },
     "autoload": {
         "psr-4": {
@@ -72,7 +72,8 @@
         }
     },
     "config": {
-        "allow-plugins": false
+        "allow-plugins": false,
+        "sort-packages": true
     },
     "scripts": {
         "fix-cs": "php-cs-fixer fix --config=.php-cs-fixer.php -v --show-progress=dots",


### PR DESCRIPTION
| :ticket: Issue | IBX-8119 |
|----------------|-----------|

#### Description:

This PR bumps the minimum required version of PHP to 8.3.
`>=8.3` version constraint is set with expectation of compatibility with version PHP 9.

Additionally, this PR:
 * enforces sorting of packages within `require` and `require-dev` sections of composer.json file
 * replaces `~5.0.0@dev` declarations with their more development friendly `~5.0.x-dev`.
 * adjusts github workflows to match new PHP version
 * updates GH action versions

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!--
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes)
-->
