### PR TITLE
IBX-8309: the order of str_replace execution has been changed to match what was before the changes

### DIFF
--- a/src/lib/Schema/Domain/Content/Mapper/FieldDefinition/ResolverVariables.php
+++ b/src/lib/Schema/Domain/Content/Mapper/FieldDefinition/ResolverVariables.php
@@ -38,19 +38,7 @@ class ResolverVariables implements FieldDefinitionMapper
     public function mapToFieldValueResolver(FieldDefinition $fieldDefinition): string
     {
         $resolver = $this->innerMapper->mapToFieldValueResolver($fieldDefinition);
-
-        //we make sure no "field" (case insensitive) keyword in the actual field's identifier gets replaced
-        //only syntax like: '@=resolver("MatrixFieldValue", [value, "field_matrix"])' needs to be taken into account
-        //where [value, "field_matrix"] stands for the actual field's identifier
-        if (preg_match('/value, "(.*field.*)"/i', $resolver) !== 1) {
-            $resolver = str_replace(
-                'field',
-                'resolver("ItemFieldValue", [value, "' . $fieldDefinition->identifier . '", args])',
-                $resolver
-            );
-        }
-
-        return str_replace(
+        $resolver = str_replace(
             [
                 'content',
                 'location',
@@ -63,6 +51,19 @@ class ResolverVariables implements FieldDefinitionMapper
             ],
             $resolver
         );
+
+        //we make sure no "field" (case insensitive) keyword in the actual field's identifier gets replaced
+        //only syntax like: '@=resolver("MatrixFieldValue", [value, "field_matrix"])' needs to be taken into account
+        //where [value, "field_matrix"] stands for the actual field's identifier
+        if (preg_match('/value, "(.*field.*)"/i', $resolver) !== 1) {
+            $resolver = str_replace(
+                'field',
+                'resolver("ItemFieldValue", [value, "' . $fieldDefinition->identifier . '", args])',
+                $resolver
+            );
+        }
+
+        return $resolver;
     }
 
     public function mapToFieldValueInputType(ContentType $contentType, FieldDefinition $fieldDefinition): ?string


### PR DESCRIPTION
| :ticket: Issue | IBX-8309 |
|----------------|-----------|


Before the changes we had str_replace which looked like this:
```
 $resolver = str_replace(
            [
                'content',
                'location',
                'item',
                'field',
            ],
            [
                'value.getContent()',
                'value.getLocation()',
                'value',
                'resolver("DomainFieldValue", [value, "' . $fieldDefinition->identifier . '"])',
            ],
            $resolver
        );
```

which did not replace the identifiers of fields that contained strings such as: `content`, `location`, `item`.
After changes, we first change the field to the `resolver(...` and then we use `str_replace` to replace the rest, which causes even the field identifiers to be changed. to prevent this, I moved `str_replace` before replace field to `resolver(...` so that it does not affect the identifiers


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
