### PR TITLE
IBX-7603: Added missing subfield for ezurl

### DIFF
--- a/src/bundle/Resources/config/default_settings.yaml
+++ b/src/bundle/Resources/config/default_settings.yaml
@@ -1,4 +1,5 @@
 parameters:
+  ibexa.graphql.schema.should.extend.ezurl: false
   ibexa.graphql.schema.content.field_name.override:
     id: id_
   ibexa.graphql.schema.content.mapping.field_definition_type:

--- a/src/bundle/Resources/config/graphql/Field.types.yaml
+++ b/src/bundle/Resources/config/graphql/Field.types.yaml
@@ -266,3 +266,16 @@ SelectionFieldValue:
                 type: "String"
                 description: "String representation of the value"
                 resolve: "@=value"
+
+UrlFieldValue:
+    type: object
+    config:
+        fields:
+            link:
+                type: String
+                description: "The link's URL"
+                resolve: "@=value.link"
+            text:
+                type: String
+                description: "The link's name or description"
+                resolve: "@=value.text"

--- a/src/bundle/Resources/config/services/schema.yaml
+++ b/src/bundle/Resources/config/services/schema.yaml
@@ -49,6 +49,12 @@ services:
         arguments:
             $innerMapper: '@Ibexa\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition\SelectionFieldDefinitionMapper.inner'
 
+    Ibexa\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition\UrlFieldDefinitionMapper:
+        decorates: Ibexa\Contracts\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionMapper
+        arguments:
+            $innerMapper: '@Ibexa\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition\UrlFieldDefinitionMapper.inner'
+            $shouldExtendUrlInputType: '%ibexa.graphql.schema.should.extend.ezurl%'
+
     Ibexa\GraphQL\Schema\Domain\Content\Worker\FieldDefinition\AddFieldValueToDomainContent: ~
 
     Ibexa\GraphQL\Schema\Domain\Content\Worker\ContentType\AddItemOfTypeConnectionToGroup: ~

--- a/src/lib/Schema/Domain/Content/Mapper/FieldDefinition/UrlFieldDefinitionMapper.php
+++ b/src/lib/Schema/Domain/Content/Mapper/FieldDefinition/UrlFieldDefinitionMapper.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition;
+
+use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
+use Ibexa\Contracts\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionMapper;
+
+final class UrlFieldDefinitionMapper extends DecoratingFieldDefinitionMapper implements FieldDefinitionMapper
+{
+    private const FIELD_TYPE_IDENTIFIER = 'ezurl';
+
+    private bool $shouldExtendUrlInputType;
+
+    public function __construct(
+        FieldDefinitionMapper $innerMapper,
+        bool $shouldExtendUrlInputType
+    ) {
+        parent::__construct($innerMapper);
+        $this->shouldExtendUrlInputType = $shouldExtendUrlInputType;
+    }
+
+    public function mapToFieldValueType(FieldDefinition $fieldDefinition): string
+    {
+        $type = parent::mapToFieldValueType($fieldDefinition);
+        if (!$this->canMap($fieldDefinition)) {
+            return $type;
+        }
+
+        if ($this->shouldExtendUrlInputType) {
+            $type = 'UrlFieldValue';
+        } else {
+            @trigger_error(
+                'The return type `string` for the URL field has been deprecated since version 4.6 ' .
+                'and will be removed in version 5.0. To start receiving `UrlFieldInput` instead of the deprecated ' .
+                '`string`, set the parameter `ibexa.graphql.schema.should.extend.ezurl` to `true`.',
+                E_USER_DEPRECATED
+            );
+        }
+
+        return $type;
+    }
+
+    protected function getFieldTypeIdentifier(): string
+    {
+        return self::FIELD_TYPE_IDENTIFIER;
+    }
+}


### PR DESCRIPTION
| :ticket: Issue | IBX-7603 |
|----------------|-----------|

#### Description:
If the `ibexa.graphql.schema.should.extend.ezurl` parameter is `false` (default), the graphQL query will look like before, i.e.:
```
{
  content {
    urlCT(contentId:68) {
      urlField
    }
  }
}
```

but if we set this parameter to `true`, the graphQL query will look like this:
```
{
  content {
    urlCT(contentId:68) {
      urlField {
        link,
        text
      }
    }
  }
}
```

This is port to 4.6 from https://github.com/ezsystems/ezplatform-graphql/pull/137

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
