### PR TITLE
IBX-9040: Fixed return in `updateDomainContent` method to Item

### DIFF
--- a/src/lib/Resolver/DomainContentMutationResolver.php
+++ b/src/lib/Resolver/DomainContentMutationResolver.php
@@ -55,7 +55,7 @@ class DomainContentMutationResolver
         $this->itemFactory = $relatedContentItemFactory;
     }
 
-    public function updateDomainContent($input, Argument $args, $versionNo, $language): RepositoryValues\Content\Content
+    public function updateDomainContent($input, Argument $args, $versionNo, $language): Item
     {
         if (isset($args['id'])) {
             $idArray = GlobalId::fromGlobalId($args['id']);
@@ -136,7 +136,7 @@ class DomainContentMutationResolver
             throw new UserError('You are not authorized to publish this version');
         }
 
-        return $this->getContentService()->loadContent($contentDraft->id);
+        return $this->itemFactory->fromContent($this->getContentService()->loadContent($contentDraft->id));
     }
 
     public function createDomainContent($input, $contentTypeIdentifier, $parentLocationId, $language): Item


### PR DESCRIPTION
| :ticket: Issue | IBX-9040 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
This is a fix for a small oversight in https://github.com/ibexa/graphql/pull/46
When requesting data back after performing an update mutation, certain fields would throw 500 because we are returning Content instead of Item. This behavior has been fixed here.


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
