### PR TITLE
IBX-9584: Resolved Symfony 6.x deprecations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,31 @@ jobs:
             - name: Run code style check
               run: composer run-script check-cs -- --format=checkstyle | cs2pr
 
+    rector:
+        name: Run rector
+        runs-on: "ubuntu-22.04"
+        strategy:
+            matrix:
+                php:
+                    - '8.3'
+        steps:
+            -   uses: actions/checkout@v4
+
+            -   name: Setup PHP Action
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php }}
+                    coverage: none
+                    extensions: 'pdo_sqlite, gd'
+                    tools: cs2pr
+
+            - uses: ramsey/composer-install@v3
+              with:
+                  dependency-versions: highest
+
+            - name: Run rector
+              run: vendor/bin/rector process --dry-run --ansi
+
     tests:
         name: Unit tests
         runs-on: "ubuntu-22.04"

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
         "ibexa/doctrine-schema": "~5.0.x-dev",
         "ibexa/http-cache": "~5.0.x-dev",
         "ibexa/notifications": "~5.0.x-dev",
+        "ibexa/rector": "~5.0.x-dev",
         "ibexa/search": "~5.0.x-dev",
         "ibexa/user": "~5.0.x-dev",
         "mikey179/vfsstream": "^1.6",

--- a/rector.php
+++ b/rector.php
@@ -19,4 +19,7 @@ return RectorConfig::configure()
         IbexaSetList::IBEXA_50->value,
         SymfonySetList::SYMFONY_60,
         SymfonySetList::SYMFONY_61,
+        SymfonySetList::SYMFONY_62,
+        SymfonySetList::SYMFONY_63,
+        SymfonySetList::SYMFONY_64,
     ]);

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+use Ibexa\Contracts\Rector\Sets\IbexaSetList;
+use Rector\Config\RectorConfig;
+use Rector\Symfony\Set\SymfonySetList;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/src',
+        __DIR__ . '/spec',
+    ])
+    ->withSets([
+        IbexaSetList::IBEXA_50->value,
+        SymfonySetList::SYMFONY_60,
+        SymfonySetList::SYMFONY_61,
+    ]);

--- a/src/bundle/Command/GeneratePlatformSchemaCommand.php
+++ b/src/bundle/Command/GeneratePlatformSchemaCommand.php
@@ -9,6 +9,7 @@ namespace Ibexa\Bundle\GraphQL\Command;
 
 use Ibexa\Contracts\Core\Repository\Repository;
 use Ibexa\GraphQL\Schema\Generator;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -17,6 +18,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Yaml\Yaml;
 
+#[AsCommand(
+    name: 'ibexa:graphql:generate-schema',
+    description: 'Generates the GraphQL schema for the Ibexa DXP instance',
+    aliases: ['ezplatform:graphql:generate-schema']
+)]
 class GeneratePlatformSchemaCommand extends Command
 {
     /**
@@ -42,9 +48,6 @@ class GeneratePlatformSchemaCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('ibexa:graphql:generate-schema')
-            ->setAliases(['ezplatform:graphql:generate-schema'])
-            ->setDescription('Generates the GraphQL schema for the Ibexa DXP instance')
             ->addOption('dry-run', null, InputOption::VALUE_OPTIONAL, 'Do not write, output the schema only', false)
             ->addOption('include', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Type to output or write', [])
             ->addOption(

--- a/src/bundle/Command/GeneratePlatformSchemaCommand.php
+++ b/src/bundle/Command/GeneratePlatformSchemaCommand.php
@@ -21,7 +21,6 @@ use Symfony\Component\Yaml\Yaml;
 #[AsCommand(
     name: 'ibexa:graphql:generate-schema',
     description: 'Generates the GraphQL schema for the Ibexa DXP instance',
-    aliases: ['ezplatform:graphql:generate-schema']
 )]
 class GeneratePlatformSchemaCommand extends Command
 {


### PR DESCRIPTION
| :ticket: Issue | IBX-9584 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:

Enabled and executed automatic refactoring rules defined for Symfony 6.x.

* [CLI] Replaced deprecated Command::{$defaultName, $defaultDescription} with the AsCommand attribute
* [CLI] Dropped ezplatform:graphql:generate-schema alias

Additionally added rector job to CI setup to prevent merging up code which is not compatible with Symfony 6+. 

#### For QA:

Sanities.

#### Documentation:

N/A

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
