### PR TITLE
IBX-9727: Added missing type hints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,9 +45,9 @@
         "mikey179/vfsstream": "^1.6",
         "overblog/graphiql-bundle": "^1.0",
         "phpspec/phpspec": "^7.1",
-        "phpstan/phpstan": "^1.10",
-        "phpstan/phpstan-phpunit": "^1.3",
-        "phpstan/phpstan-symfony": "^1.3"
+        "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpstan/phpstan-symfony": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,2116 +1,1459 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Cannot call method find\\(\\) on Symfony\\\\Component\\\\Console\\\\Application\\|null\\.$#"
+			message: '#^Cannot call method find\(\) on Symfony\\Component\\Console\\Application\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/bundle/Command/GeneratePlatformSchemaCommand.php
 
 		-
-			message: "#^Method Ibexa\\\\Bundle\\\\GraphQL\\\\Command\\\\GeneratePlatformSchemaCommand\\:\\:compileTypes\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/bundle/Command/GeneratePlatformSchemaCommand.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\GraphQL\\\\DependencyInjection\\\\GraphQL\\\\SchemaProvider\\:\\:getSchemaConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\Bundle\\GraphQL\\DependencyInjection\\GraphQL\\SchemaProvider\:\:getSchemaConfiguration\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/bundle/DependencyInjection/GraphQL/SchemaProvider.php
 
 		-
-			message: "#^Method Ibexa\\\\Bundle\\\\GraphQL\\\\DependencyInjection\\\\GraphQL\\\\YamlSchemaProvider\\:\\:__construct\\(\\) has parameter \\$graphQLConfigRoot with no type specified\\.$#"
+			message: '#^Method Ibexa\\Bundle\\GraphQL\\DependencyInjection\\GraphQL\\YamlSchemaProvider\:\:__construct\(\) has parameter \$graphQLConfigRoot with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/bundle/DependencyInjection/GraphQL/YamlSchemaProvider.php
 
 		-
-			message: "#^Method Ibexa\\\\Bundle\\\\GraphQL\\\\DependencyInjection\\\\GraphQL\\\\YamlSchemaProvider\\:\\:getAppMutationSchemaFile\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\Bundle\\GraphQL\\DependencyInjection\\GraphQL\\YamlSchemaProvider\:\:getSchemaConfiguration\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/bundle/DependencyInjection/GraphQL/YamlSchemaProvider.php
 
 		-
-			message: "#^Method Ibexa\\\\Bundle\\\\GraphQL\\\\DependencyInjection\\\\GraphQL\\\\YamlSchemaProvider\\:\\:getAppQuerySchema\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/bundle/DependencyInjection/GraphQL/YamlSchemaProvider.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\GraphQL\\\\DependencyInjection\\\\GraphQL\\\\YamlSchemaProvider\\:\\:getMutationSchema\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/bundle/DependencyInjection/GraphQL/YamlSchemaProvider.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\GraphQL\\\\DependencyInjection\\\\GraphQL\\\\YamlSchemaProvider\\:\\:getPlatformMutationSchema\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/bundle/DependencyInjection/GraphQL/YamlSchemaProvider.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\GraphQL\\\\DependencyInjection\\\\GraphQL\\\\YamlSchemaProvider\\:\\:getPlatformQuerySchema\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/bundle/DependencyInjection/GraphQL/YamlSchemaProvider.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\GraphQL\\\\DependencyInjection\\\\GraphQL\\\\YamlSchemaProvider\\:\\:getQuerySchema\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/bundle/DependencyInjection/GraphQL/YamlSchemaProvider.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\GraphQL\\\\DependencyInjection\\\\GraphQL\\\\YamlSchemaProvider\\:\\:getSchemaConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/bundle/DependencyInjection/GraphQL/YamlSchemaProvider.php
-
-		-
-			message: "#^Binary operation \"\\.\" between array\\|bool\\|float\\|int\\|string\\|null and '/config/graphql…' results in an error\\.$#"
+			message: '#^Binary operation "\." between array\|bool\|float\|int\|string\|null and ''/config/graphql…'' results in an error\.$#'
+			identifier: binaryOp.invalid
 			count: 1
 			path: src/bundle/DependencyInjection/IbexaGraphQLExtension.php
 
 		-
-			message: "#^Binary operation \"\\.\" between array\\|bool\\|float\\|int\\|string\\|null and '/src/bundle…' results in an error\\.$#"
+			message: '#^Binary operation "\." between array\|bool\|float\|int\|string\|null and ''/src/bundle…'' results in an error\.$#'
+			identifier: binaryOp.invalid
 			count: 1
 			path: src/bundle/DependencyInjection/IbexaGraphQLExtension.php
 
 		-
-			message: "#^Method Ibexa\\\\Bundle\\\\GraphQL\\\\DependencyInjection\\\\IbexaGraphQLExtension\\:\\:getGraphQLConfig\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\Bundle\\GraphQL\\DependencyInjection\\IbexaGraphQLExtension\:\:getGraphQLConfig\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/bundle/DependencyInjection/IbexaGraphQLExtension.php
 
 		-
-			message: "#^Method Ibexa\\\\Bundle\\\\GraphQL\\\\DependencyInjection\\\\IbexaGraphQLExtension\\:\\:load\\(\\) has no return type specified\\.$#"
+			message: '#^Parameter \#1 \$configDir of method Ibexa\\Bundle\\GraphQL\\DependencyInjection\\IbexaGraphQLExtension\:\:getGraphQLConfig\(\) expects string, array\|bool\|float\|int\|string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/bundle/DependencyInjection/IbexaGraphQLExtension.php
 
 		-
-			message: "#^Parameter \\#1 \\$configDir of method Ibexa\\\\Bundle\\\\GraphQL\\\\DependencyInjection\\\\IbexaGraphQLExtension\\:\\:getGraphQLConfig\\(\\) expects string, array\\|bool\\|float\\|int\\|string\\|null given\\.$#"
+			message: '#^Parameter \#1 \$string of function rtrim expects string, array\|bool\|float\|int\|string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/bundle/DependencyInjection/IbexaGraphQLExtension.php
 
 		-
-			message: "#^Parameter \\#1 \\$string of function rtrim expects string, array\\|bool\\|float\\|int\\|string\\|null given\\.$#"
-			count: 1
-			path: src/bundle/DependencyInjection/IbexaGraphQLExtension.php
-
-		-
-			message: "#^Method Ibexa\\\\Contracts\\\\GraphQL\\\\Mutation\\\\InputHandler\\\\FieldType\\\\RichText\\\\RichTextInputConverter\\:\\:convertToXml\\(\\) has parameter \\$text with no type specified\\.$#"
+			message: '#^Method Ibexa\\Contracts\\GraphQL\\Mutation\\InputHandler\\FieldType\\RichText\\RichTextInputConverter\:\:convertToXml\(\) has parameter \$text with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/contracts/Mutation/InputHandler/FieldType/RichText/RichTextInputConverter.php
 
 		-
-			message: "#^Method Ibexa\\\\Contracts\\\\GraphQL\\\\Mutation\\\\InputHandler\\\\FieldTypeInputHandler\\:\\:toFieldValue\\(\\) has parameter \\$input with no type specified\\.$#"
+			message: '#^Method Ibexa\\Contracts\\GraphQL\\Mutation\\InputHandler\\FieldTypeInputHandler\:\:toFieldValue\(\) has parameter \$input with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/contracts/Mutation/InputHandler/FieldTypeInputHandler.php
 
 		-
-			message: "#^Method Ibexa\\\\Contracts\\\\GraphQL\\\\Mutation\\\\InputHandler\\\\FieldTypeInputHandler\\:\\:toFieldValue\\(\\) has parameter \\$inputFormat with no type specified\\.$#"
+			message: '#^Method Ibexa\\Contracts\\GraphQL\\Mutation\\InputHandler\\FieldTypeInputHandler\:\:toFieldValue\(\) has parameter \$inputFormat with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/contracts/Mutation/InputHandler/FieldTypeInputHandler.php
 
 		-
-			message: "#^Cannot access offset 0 on array\\<bool\\|float\\|int\\|string\\>\\|bool\\|float\\|int\\|string\\.$#"
+			message: '#^Cannot access offset 0 on array\<bool\|float\|int\|string\>\|bool\|float\|int\|string\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
 			path: src/lib/DataLoader/CachedContentLoader.php
 
 		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\DataLoader\\\\CachedContentLoader\\:\\:\\$loadedItems has no type specified\\.$#"
+			message: '#^Property Ibexa\\GraphQL\\DataLoader\\CachedContentLoader\:\:\$loadedItems has no type specified\.$#'
+			identifier: missingType.property
 			count: 1
 			path: src/lib/DataLoader/CachedContentLoader.php
 
 		-
-			message: "#^Cannot access offset mixed on Ibexa\\\\GraphQL\\\\DataLoader\\\\ContentTypeLoader\\.$#"
+			message: '#^Cannot access offset mixed on Ibexa\\GraphQL\\DataLoader\\ContentTypeLoader\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
 			count: 2
 			path: src/lib/DataLoader/CachedContentTypeLoader.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\DataLoader\\\\CachedContentTypeLoader\\:\\:load\\(\\) has parameter \\$contentTypeId with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\DataLoader\\CachedContentTypeLoader\:\:load\(\) has parameter \$contentTypeId with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/DataLoader/CachedContentTypeLoader.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\DataLoader\\\\CachedContentTypeLoader\\:\\:loadByIdentifier\\(\\) has parameter \\$identifier with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\DataLoader\\CachedContentTypeLoader\:\:loadByIdentifier\(\) has parameter \$identifier with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/DataLoader/CachedContentTypeLoader.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\DataLoader\\\\ContentTypeLoader\\:\\:load\\(\\) has parameter \\$contentTypeId with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\DataLoader\\ContentTypeLoader\:\:load\(\) has parameter \$contentTypeId with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/DataLoader/ContentTypeLoader.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\DataLoader\\\\ContentTypeLoader\\:\\:loadByIdentifier\\(\\) has parameter \\$identifier with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\DataLoader\\ContentTypeLoader\:\:loadByIdentifier\(\) has parameter \$identifier with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/DataLoader/ContentTypeLoader.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\DataLoader\\\\RepositoryContentTypeLoader\\:\\:load\\(\\) has parameter \\$contentTypeId with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\DataLoader\\RepositoryContentTypeLoader\:\:load\(\) has parameter \$contentTypeId with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/DataLoader/RepositoryContentTypeLoader.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\DataLoader\\\\RepositoryContentTypeLoader\\:\\:loadByIdentifier\\(\\) has parameter \\$identifier with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\DataLoader\\RepositoryContentTypeLoader\:\:loadByIdentifier\(\) has parameter \$identifier with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/DataLoader/RepositoryContentTypeLoader.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\DataLoader\\\\SearchContentLoader\\:\\:count\\(\\) should return int but returns int\\<0, max\\>\\|null\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\DataLoader\\SearchContentLoader\:\:count\(\) should return int but returns int\<0, max\>\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: src/lib/DataLoader/SearchContentLoader.php
 
 		-
-			message: "#^Dead catch \\- Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Exceptions\\\\InvalidArgumentException is never thrown in the try block\\.$#"
+			message: '#^Dead catch \- Ibexa\\Contracts\\Core\\Repository\\Exceptions\\InvalidArgumentException is never thrown in the try block\.$#'
+			identifier: catch.neverThrown
 			count: 2
 			path: src/lib/DataLoader/SearchLocationLoader.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\DataLoader\\\\SearchLocationLoader\\:\\:count\\(\\) should return int but returns int\\<0, max\\>\\|null\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\DataLoader\\SearchLocationLoader\:\:count\(\) should return int but returns int\<0, max\>\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: src/lib/DataLoader/SearchLocationLoader.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\DataLoader\\\\SearchLocationLoader\\:\\:findByUrlAlias\\(\\) should return Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location but returns Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location\\|null\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\DataLoader\\SearchLocationLoader\:\:findByUrlAlias\(\) should return Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Location but returns Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Location\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: src/lib/DataLoader/SearchLocationLoader.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\DataLoader\\\\SearchLocationLoader\\:\\:getUrlAlias\\(\\) has parameter \\$pathinfo with no type specified\\.$#"
+			message: '#^PHPDoc tag @param for parameter \$query with type Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Query is not subtype of native type Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\LocationQuery\.$#'
+			identifier: parameter.phpDocType
 			count: 1
 			path: src/lib/DataLoader/SearchLocationLoader.php
 
 		-
-			message: "#^PHPDoc tag @param for parameter \\$query with type Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Query is not subtype of native type Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\LocationQuery\\.$#"
+			message: '#^Parameter \#1 \$locationId of method Ibexa\\Contracts\\Core\\Repository\\LocationService\:\:loadLocation\(\) expects int, string given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/lib/DataLoader/SearchLocationLoader.php
 
 		-
-			message: "#^Parameter \\#1 \\$locationId of method Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\LocationService\\:\\:loadLocation\\(\\) expects int, string given\\.$#"
-			count: 1
-			path: src/lib/DataLoader/SearchLocationLoader.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Exception\\\\NoValidLocationsException\\:\\:getContent\\(\\) should return Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Content but returns array\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Content\\>\\|Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Content\\.$#"
-			count: 1
-			path: src/lib/Exception/NoValidLocationsException.php
-
-		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Exception\\\\NoValidSiteaccessException\\:\\:\\$location is never read, only written\\.$#"
+			message: '#^Property Ibexa\\GraphQL\\Exception\\NoValidSiteaccessException\:\:\$location is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: src/lib/Exception/NoValidSiteaccessException.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Exception\\\\UnsupportedFieldInputFormatException\\:\\:__construct\\(\\) has parameter \\$fieldType with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Exception\\UnsupportedFieldInputFormatException\:\:__construct\(\) has parameter \$fieldType with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Exception/UnsupportedFieldInputFormatException.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Exception\\\\UnsupportedFieldInputFormatException\\:\\:__construct\\(\\) has parameter \\$format with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Exception\\UnsupportedFieldInputFormatException\:\:__construct\(\) has parameter \$format with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Exception/UnsupportedFieldInputFormatException.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Exception\\\\UnsupportedFieldTypeException\\:\\:__construct\\(\\) has parameter \\$fieldType with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Exception\\UnsupportedFieldTypeException\:\:__construct\(\) has parameter \$fieldType with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Exception/UnsupportedFieldTypeException.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Exception\\\\UnsupportedFieldTypeException\\:\\:__construct\\(\\) has parameter \\$operation with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Exception\\UnsupportedFieldTypeException\:\:__construct\(\) has parameter \$operation with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Exception/UnsupportedFieldTypeException.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\InputMapper\\\\QueryMapper\\:\\:mapInputToLocationQuery\\(\\) has parameter \\$inputArray with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\InputMapper\\QueryMapper\:\:mapInputToLocationQuery\(\) has parameter \$inputArray with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/InputMapper/QueryMapper.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\InputMapper\\\\QueryMapper\\:\\:mapInputToQuery\\(\\) has parameter \\$inputArray with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\InputMapper\\QueryMapper\:\:mapInputToQuery\(\) has parameter \$inputArray with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/InputMapper/QueryMapper.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\InputMapper\\\\SearchQueryMapper\\:\\:mapDateMetadata\\(\\) has parameter \\$dateMetadata with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\InputMapper\\SearchQueryMapper\:\:mapDateMetadata\(\) has parameter \$queryArg with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/InputMapper/SearchQueryMapper.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\InputMapper\\\\SearchQueryMapper\\:\\:mapDateMetadata\\(\\) has parameter \\$queryArg with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\InputMapper\\SearchQueryMapper\:\:mapInputToFieldCriterion\(\) has parameter \$input with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/InputMapper/SearchQueryMapper.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\InputMapper\\\\SearchQueryMapper\\:\\:mapInput\\(\\) has parameter \\$inputArray with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\InputMapper\\SearchQueryMapper\:\:mapInputToLocationQuery\(\) has parameter \$inputArray with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/InputMapper/SearchQueryMapper.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\InputMapper\\\\SearchQueryMapper\\:\\:mapInput\\(\\) has parameter \\$query with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\InputMapper\\SearchQueryMapper\:\:mapInputToQuery\(\) has parameter \$inputArray with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/InputMapper/SearchQueryMapper.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\InputMapper\\\\SearchQueryMapper\\:\\:mapInputToFieldCriterion\\(\\) has no return type specified\\.$#"
+			message: '#^Strict comparison using \=\=\= between int\<1, max\> and 0 will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
 			count: 1
 			path: src/lib/InputMapper/SearchQueryMapper.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\InputMapper\\\\SearchQueryMapper\\:\\:mapInputToFieldCriterion\\(\\) has parameter \\$input with no type specified\\.$#"
+			message: '#^Variable \$value might not be defined\.$#'
+			identifier: variable.undefined
 			count: 1
 			path: src/lib/InputMapper/SearchQueryMapper.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\InputMapper\\\\SearchQueryMapper\\:\\:mapInputToLocationQuery\\(\\) has parameter \\$inputArray with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/InputMapper/SearchQueryMapper.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\InputMapper\\\\SearchQueryMapper\\:\\:mapInputToQuery\\(\\) has parameter \\$inputArray with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/InputMapper/SearchQueryMapper.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between int\\<1, max\\> and 0 will always evaluate to false\\.$#"
-			count: 1
-			path: src/lib/InputMapper/SearchQueryMapper.php
-
-		-
-			message: "#^Variable \\$value might not be defined\\.$#"
-			count: 1
-			path: src/lib/InputMapper/SearchQueryMapper.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\InputMapper\\\\SearchQuerySortByMapper\\:\\:mapInputToSortClauses\\(\\) should return array\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\URL\\\\Query\\\\SortClause\\> but returns array\\<object\\>\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\InputMapper\\SearchQuerySortByMapper\:\:mapInputToSortClauses\(\) should return array\<Ibexa\\Contracts\\Core\\Repository\\Values\\URL\\Query\\SortClause\> but returns array\<object\>\.$#'
+			identifier: return.type
 			count: 1
 			path: src/lib/InputMapper/SearchQuerySortByMapper.php
 
 		-
-			message: "#^Access to an undefined property Ibexa\\\\Core\\\\FieldType\\\\ImageAsset\\\\Value\\:\\:\\$source\\.$#"
+			message: '#^Access to an undefined property Ibexa\\Core\\FieldType\\ImageAsset\\Value\:\:\$source\.$#'
+			identifier: property.notFound
 			count: 1
 			path: src/lib/Mapper/ContentImageAssetMapperStrategy.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\InputHandler\\\\FieldType\\\\BinaryFile\\:\\:toFieldValue\\(\\) has parameter \\$input with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Mutation\\InputHandler\\FieldType\\BinaryFile\:\:toFieldValue\(\) has parameter \$input with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Mutation/InputHandler/FieldType/BinaryFile.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\InputHandler\\\\FieldType\\\\BinaryFile\\:\\:toFieldValue\\(\\) has parameter \\$inputFormat with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Mutation\\InputHandler\\FieldType\\BinaryFile\:\:toFieldValue\(\) has parameter \$inputFormat with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Mutation/InputHandler/FieldType/BinaryFile.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\InputHandler\\\\FieldType\\\\BinaryFile\\:\\:toFieldValue\\(\\) should return Ibexa\\\\Contracts\\\\Core\\\\FieldType\\\\Value but returns null\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Mutation\\InputHandler\\FieldType\\BinaryFile\:\:toFieldValue\(\) should return Ibexa\\Contracts\\Core\\FieldType\\Value but returns null\.$#'
+			identifier: return.type
 			count: 1
 			path: src/lib/Mutation/InputHandler/FieldType/BinaryFile.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\InputHandler\\\\FieldType\\\\Date\\:\\:toFieldValue\\(\\) has parameter \\$input with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Mutation\\InputHandler\\FieldType\\Date\:\:toFieldValue\(\) has parameter \$input with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Mutation/InputHandler/FieldType/Date.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\InputHandler\\\\FieldType\\\\Date\\:\\:toFieldValue\\(\\) has parameter \\$inputFormat with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Mutation\\InputHandler\\FieldType\\Date\:\:toFieldValue\(\) has parameter \$inputFormat with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Mutation/InputHandler/FieldType/Date.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\InputHandler\\\\FieldType\\\\FromHash\\:\\:toFieldValue\\(\\) has parameter \\$input with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Mutation\\InputHandler\\FieldType\\FromHash\:\:toFieldValue\(\) has parameter \$input with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Mutation/InputHandler/FieldType/FromHash.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\InputHandler\\\\FieldType\\\\FromHash\\:\\:toFieldValue\\(\\) has parameter \\$inputFormat with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Mutation\\InputHandler\\FieldType\\FromHash\:\:toFieldValue\(\) has parameter \$inputFormat with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Mutation/InputHandler/FieldType/FromHash.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\InputHandler\\\\FieldType\\\\Image\\:\\:toFieldValue\\(\\) has parameter \\$input with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Mutation\\InputHandler\\FieldType\\Image\:\:toFieldValue\(\) has parameter \$input with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Mutation/InputHandler/FieldType/Image.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\InputHandler\\\\FieldType\\\\Image\\:\\:toFieldValue\\(\\) has parameter \\$inputFormat with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Mutation\\InputHandler\\FieldType\\Image\:\:toFieldValue\(\) has parameter \$inputFormat with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Mutation/InputHandler/FieldType/Image.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\InputHandler\\\\FieldType\\\\Image\\:\\:toFieldValue\\(\\) should return Ibexa\\\\Contracts\\\\Core\\\\FieldType\\\\Value but returns null\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Mutation\\InputHandler\\FieldType\\Image\:\:toFieldValue\(\) should return Ibexa\\Contracts\\Core\\FieldType\\Value but returns null\.$#'
+			identifier: return.type
 			count: 1
 			path: src/lib/Mutation/InputHandler/FieldType/Image.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\InputHandler\\\\FieldType\\\\Media\\:\\:toFieldValue\\(\\) has parameter \\$input with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Mutation\\InputHandler\\FieldType\\Media\:\:toFieldValue\(\) has parameter \$input with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Mutation/InputHandler/FieldType/Media.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\InputHandler\\\\FieldType\\\\Media\\:\\:toFieldValue\\(\\) has parameter \\$inputFormat with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Mutation\\InputHandler\\FieldType\\Media\:\:toFieldValue\(\) has parameter \$inputFormat with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Mutation/InputHandler/FieldType/Media.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\InputHandler\\\\FieldType\\\\Media\\:\\:toFieldValue\\(\\) should return Ibexa\\\\Contracts\\\\Core\\\\FieldType\\\\Value but returns null\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Mutation\\InputHandler\\FieldType\\Media\:\:toFieldValue\(\) should return Ibexa\\Contracts\\Core\\FieldType\\Value but returns null\.$#'
+			identifier: return.type
 			count: 1
 			path: src/lib/Mutation/InputHandler/FieldType/Media.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\InputHandler\\\\FieldType\\\\Relation\\:\\:toFieldValue\\(\\) has parameter \\$input with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Mutation\\InputHandler\\FieldType\\Relation\:\:toFieldValue\(\) has parameter \$input with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Mutation/InputHandler/FieldType/Relation.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\InputHandler\\\\FieldType\\\\Relation\\:\\:toFieldValue\\(\\) has parameter \\$inputFormat with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Mutation\\InputHandler\\FieldType\\Relation\:\:toFieldValue\(\) has parameter \$inputFormat with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Mutation/InputHandler/FieldType/Relation.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\InputHandler\\\\FieldType\\\\RelationList\\:\\:toFieldValue\\(\\) has parameter \\$input with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Mutation\\InputHandler\\FieldType\\RelationList\:\:toFieldValue\(\) has parameter \$input with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Mutation/InputHandler/FieldType/RelationList.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\InputHandler\\\\FieldType\\\\RelationList\\:\\:toFieldValue\\(\\) has parameter \\$inputFormat with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Mutation\\InputHandler\\FieldType\\RelationList\:\:toFieldValue\(\) has parameter \$inputFormat with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Mutation/InputHandler/FieldType/RelationList.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\InputHandler\\\\FieldType\\\\RichText\\:\\:__construct\\(\\) has parameter \\$inputConverters with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Mutation\\InputHandler\\FieldType\\RichText\:\:__construct\(\) has parameter \$inputConverters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Mutation/InputHandler/FieldType/RichText.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\InputHandler\\\\FieldType\\\\RichText\\:\\:toFieldValue\\(\\) has parameter \\$input with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Mutation\\InputHandler\\FieldType\\RichText\:\:toFieldValue\(\) has parameter \$input with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Mutation/InputHandler/FieldType/RichText.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\InputHandler\\\\FieldType\\\\RichText\\\\HtmlRichTextConverter\\:\\:convertToXml\\(\\) has parameter \\$text with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Mutation\\InputHandler\\FieldType\\RichText\\HtmlRichTextConverter\:\:convertToXml\(\) has parameter \$text with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Mutation/InputHandler/FieldType/RichText/HtmlRichTextConverter.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\InputHandler\\\\FieldType\\\\RichText\\\\MarkdownRichTextConverter\\:\\:convertToXml\\(\\) has parameter \\$text with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Mutation\\InputHandler\\FieldType\\RichText\\MarkdownRichTextConverter\:\:convertToXml\(\) has parameter \$text with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Mutation/InputHandler/FieldType/RichText/MarkdownRichTextConverter.php
 
 		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Mutation\\\\InputHandler\\\\FieldType\\\\RichText\\\\MarkdownRichTextConverter\\:\\:\\$markdownConverter \\(Ibexa\\\\Contracts\\\\FieldTypeRichText\\\\RichText\\\\Converter\\) does not accept Parsedown\\.$#"
-			count: 1
-			path: src/lib/Mutation/InputHandler/FieldType/RichText/MarkdownRichTextConverter.php
-
-		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Mutation\\\\InputHandler\\\\FieldType\\\\RichText\\\\MarkdownRichTextConverter\\:\\:\\$markdownConverter is never read, only written\\.$#"
-			count: 1
-			path: src/lib/Mutation/InputHandler/FieldType/RichText/MarkdownRichTextConverter.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\SectionMutation\\:\\:createSection\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Mutation\\SectionMutation\:\:createSection\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/lib/Mutation/SectionMutation.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\SectionMutation\\:\\:createSection\\(\\) has parameter \\$value with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Mutation\\SectionMutation\:\:deleteSection\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/lib/Mutation/SectionMutation.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\SectionMutation\\:\\:deleteSection\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Mutation\\SectionMutation\:\:deleteSection\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Mutation/SectionMutation.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\SectionMutation\\:\\:deleteSection\\(\\) has parameter \\$value with no type specified\\.$#"
-			count: 1
-			path: src/lib/Mutation/SectionMutation.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\SectionMutation\\:\\:mapSectionToPayLoad\\(\\) has parameter \\$section with no type specified\\.$#"
-			count: 1
-			path: src/lib/Mutation/SectionMutation.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\SectionMutation\\:\\:mapSectionToPayLoad\\(\\) has parameter \\$value with no type specified\\.$#"
-			count: 1
-			path: src/lib/Mutation/SectionMutation.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\SectionMutation\\:\\:mapSectionToPayLoad\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Mutation/SectionMutation.php
-
-		-
-			message: "#^Cannot access property \\$fieldTypeIdentifier on Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\ContentType\\\\FieldDefinition\\|null\\.$#"
+			message: '#^Cannot access property \$fieldTypeIdentifier on Ibexa\\Contracts\\Core\\Repository\\Values\\ContentType\\FieldDefinition\|null\.$#'
+			identifier: property.nonObject
 			count: 1
 			path: src/lib/Mutation/UploadFiles.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\UploadFiles\\:\\:createContent\\(\\) has parameter \\$languageCode with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Mutation\\UploadFiles\:\:createContent\(\) has parameter \$mapping with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Mutation/UploadFiles.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\UploadFiles\\:\\:createContent\\(\\) has parameter \\$locationId with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Mutation\\UploadFiles\:\:mapAgainstConfig\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/lib/Mutation/UploadFiles.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\UploadFiles\\:\\:createContent\\(\\) has parameter \\$mapping with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Mutation/UploadFiles.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\UploadFiles\\:\\:mapAgainstConfig\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Mutation/UploadFiles.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\UploadFiles\\:\\:mapAgainstConfig\\(\\) has parameter \\$mimeType with no type specified\\.$#"
-			count: 1
-			path: src/lib/Mutation/UploadFiles.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Mutation\\\\UploadFiles\\:\\:uploadFiles\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Mutation/UploadFiles.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Overblog\\\\ArgsBuilder\\\\ItemArgsBuilder\\:\\:toMappingDefinition\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Overblog\\ArgsBuilder\\ItemArgsBuilder\:\:toMappingDefinition\(\) has parameter \$config with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Overblog/ArgsBuilder/ItemArgsBuilder.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Overblog\\\\ArgsBuilder\\\\ItemArgsBuilder\\:\\:toMappingDefinition\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Overblog\\ArgsBuilder\\ItemArgsBuilder\:\:toMappingDefinition\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Overblog/ArgsBuilder/ItemArgsBuilder.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Relay\\\\NodeResolver\\:\\:resolveNode\\(\\) has parameter \\$globalId with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Relay\\NodeResolver\:\:resolveNode\(\) has parameter \$globalId with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Relay/NodeResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Relay\\\\NodeResolver\\:\\:resolveType\\(\\) has parameter \\$object with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Relay\\NodeResolver\:\:resolveType\(\) has parameter \$object with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Relay/NodeResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Relay\\\\NodeResolver\\:\\:resolveType\\(\\) should return GraphQL\\\\Type\\\\Definition\\\\Type but return statement is missing\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Relay\\NodeResolver\:\:resolveType\(\) should return GraphQL\\Type\\Definition\\Type but return statement is missing\.$#'
+			identifier: return.missing
 			count: 1
 			path: src/lib/Relay/NodeResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Relay\\\\NodeResolver\\:\\:resolveType\\(\\) should return GraphQL\\\\Type\\\\Definition\\\\Type but returns GraphQL\\\\Type\\\\Definition\\\\Type\\|null\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Relay\\NodeResolver\:\:resolveType\(\) should return GraphQL\\Type\\Definition\\Type but returns GraphQL\\Type\\Definition\\Type\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: src/lib/Relay/NodeResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Relay\\\\SearchResolver\\:\\:searchContent\\(\\) has parameter \\$args with no type specified\\.$#"
-			count: 1
-			path: src/lib/Relay/SearchResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ContentResolver\\:\\:findContentByType\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\ContentResolver\:\:resolveContent\(\) has parameter \$args with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Resolver/ContentResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ContentResolver\\:\\:findContentByType\\(\\) has parameter \\$contentTypeId with no type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/ContentResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ContentResolver\\:\\:findContentRelations\\(\\) has parameter \\$version with no type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/ContentResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ContentResolver\\:\\:findContentReverseRelations\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/ContentResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ContentResolver\\:\\:resolveContent\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/ContentResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ContentResolver\\:\\:resolveContent\\(\\) has parameter \\$args with no type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/ContentResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ContentResolver\\:\\:resolveContentById\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/ContentResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ContentResolver\\:\\:resolveContentById\\(\\) has parameter \\$contentId with no type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/ContentResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ContentResolver\\:\\:resolveContentByIdList\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/ContentResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ContentResolver\\:\\:resolveContentByIdList\\(\\) has parameter \\$contentIdList with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Resolver/ContentResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ContentResolver\\:\\:resolveContentVersions\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/ContentResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ContentResolver\\:\\:resolveContentVersions\\(\\) has parameter \\$contentId with no type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/ContentResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ContentThumbnailResolver\\:\\:resolveContentThumbnail\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\ContentThumbnailResolver\:\:resolveContentThumbnail\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Resolver/ContentThumbnailResolver.php
 
 		-
-			message: "#^Parameter \\#2 \\$fields of method Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Strategy\\\\ContentThumbnail\\\\ThumbnailStrategy\\:\\:getThumbnail\\(\\) expects array, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Field\\> given\\.$#"
+			message: '#^Parameter \#2 \$fields of method Ibexa\\Contracts\\Core\\Repository\\Strategy\\ContentThumbnail\\ThumbnailStrategy\:\:getThumbnail\(\) expects array, iterable\<Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Field\> given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/lib/Resolver/ContentThumbnailResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ContentTypeResolver\\:\\:resolveContentType\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\ContentTypeResolver\:\:resolveContentType\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/lib/Resolver/ContentTypeResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ContentTypeResolver\\:\\:resolveContentType\\(\\) has parameter \\$args with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\ContentTypeResolver\:\:resolveContentType\(\) has parameter \$args with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Resolver/ContentTypeResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ContentTypeResolver\\:\\:resolveContentTypeById\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\ContentTypeResolver\:\:resolveContentTypesFromGroup\(\) has parameter \$args with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Resolver/ContentTypeResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ContentTypeResolver\\:\\:resolveContentTypeById\\(\\) has parameter \\$contentTypeId with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\ContentTypeResolver\:\:resolveContentTypesFromGroup\(\) should return array\<Ibexa\\Contracts\\Core\\Repository\\Values\\ContentType\\ContentType\> but returns iterable\<Ibexa\\Contracts\\Core\\Repository\\Values\\ContentType\\ContentType\>\.$#'
+			identifier: return.type
 			count: 1
 			path: src/lib/Resolver/ContentTypeResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ContentTypeResolver\\:\\:resolveContentTypeGroupByIdentifier\\(\\) has no return type specified\\.$#"
+			message: '#^Parameter \#2 \.\.\.\$arrays of function array_merge expects array, iterable\<Ibexa\\Contracts\\Core\\Repository\\Values\\ContentType\\ContentType\> given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/lib/Resolver/ContentTypeResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ContentTypeResolver\\:\\:resolveContentTypeGroupByIdentifier\\(\\) has parameter \\$identifier with no type specified\\.$#"
+			message: '#^Property Ibexa\\GraphQL\\Resolver\\ContentTypeResolver\:\:\$typeResolver is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: src/lib/Resolver/ContentTypeResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ContentTypeResolver\\:\\:resolveContentTypesFromGroup\\(\\) has parameter \\$args with no type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/ContentTypeResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ContentTypeResolver\\:\\:resolveContentTypesFromGroup\\(\\) should return array\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\ContentType\\\\ContentType\\> but returns iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\ContentType\\\\ContentType\\>\\.$#"
-			count: 1
-			path: src/lib/Resolver/ContentTypeResolver.php
-
-		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$arrays of function array_merge expects array, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\ContentType\\\\ContentType\\> given\\.$#"
-			count: 1
-			path: src/lib/Resolver/ContentTypeResolver.php
-
-		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Resolver\\\\ContentTypeResolver\\:\\:\\$typeResolver is never read, only written\\.$#"
-			count: 1
-			path: src/lib/Resolver/ContentTypeResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\DateResolver\\:\\:resolveDateToFormat\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\DateResolver\:\:resolveDateToFormat\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/lib/Resolver/DateResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\DateResolver\\:\\:resolveDateToFormat\\(\\) has parameter \\$args with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\DateResolver\:\:resolveDateToFormat\(\) has parameter \$args with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Resolver/DateResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\DateResolver\\:\\:resolveDateToFormat\\(\\) has parameter \\$date with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\DateResolver\:\:resolveDateToFormat\(\) has parameter \$date with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Resolver/DateResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\DomainContentMutationResolver\\:\\:__construct\\(\\) has parameter \\$fieldInputHandlers with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\DomainContentMutationResolver\:\:__construct\(\) has parameter \$fieldInputHandlers with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Resolver/DomainContentMutationResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\DomainContentMutationResolver\\:\\:createDomainContent\\(\\) has parameter \\$contentTypeIdentifier with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\DomainContentMutationResolver\:\:createDomainContent\(\) has parameter \$input with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Resolver/DomainContentMutationResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\DomainContentMutationResolver\\:\\:createDomainContent\\(\\) has parameter \\$input with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\DomainContentMutationResolver\:\:createDomainContent\(\) has parameter \$parentLocationId with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Resolver/DomainContentMutationResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\DomainContentMutationResolver\\:\\:createDomainContent\\(\\) has parameter \\$language with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\DomainContentMutationResolver\:\:getInputFieldValue\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/lib/Resolver/DomainContentMutationResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\DomainContentMutationResolver\\:\\:createDomainContent\\(\\) has parameter \\$parentLocationId with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\DomainContentMutationResolver\:\:getInputFieldValue\(\) has parameter \$fieldInput with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Resolver/DomainContentMutationResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\DomainContentMutationResolver\\:\\:deleteDomainContent\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\DomainContentMutationResolver\:\:resolveDomainContentType\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/lib/Resolver/DomainContentMutationResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\DomainContentMutationResolver\\:\\:getInputFieldValue\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\DomainContentMutationResolver\:\:updateDomainContent\(\) has parameter \$input with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Resolver/DomainContentMutationResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\DomainContentMutationResolver\\:\\:getInputFieldValue\\(\\) has parameter \\$fieldInput with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\DomainContentMutationResolver\:\:updateDomainContent\(\) has parameter \$versionNo with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Resolver/DomainContentMutationResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\DomainContentMutationResolver\\:\\:getLocationService\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/DomainContentMutationResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\DomainContentMutationResolver\\:\\:makeDomainContentTypeName\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/DomainContentMutationResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\DomainContentMutationResolver\\:\\:renderFieldValidationErrors\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/DomainContentMutationResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\DomainContentMutationResolver\\:\\:resolveDomainContentType\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/DomainContentMutationResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\DomainContentMutationResolver\\:\\:updateDomainContent\\(\\) has parameter \\$input with no type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/DomainContentMutationResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\DomainContentMutationResolver\\:\\:updateDomainContent\\(\\) has parameter \\$language with no type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/DomainContentMutationResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\DomainContentMutationResolver\\:\\:updateDomainContent\\(\\) has parameter \\$versionNo with no type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/DomainContentMutationResolver.php
-
-		-
-			message: "#^Call to method mapInputToQuery\\(\\) on an unknown class Ibexa\\\\GraphQL\\\\Resolver\\\\SearchQueryMapper\\.$#"
+			message: '#^Cannot access offset 0 on iterable\<Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\URLAlias\>\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
 			path: src/lib/Resolver/DomainContentResolver.php
 
 		-
-			message: "#^Cannot access offset 0 on iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\URLAlias\\>\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\DomainContentResolver\:\:getContentIds\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Resolver/DomainContentResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\DomainContentResolver\\:\\:getContentIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\DomainContentResolver\:\:resolveDomainContentItem\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Resolver/DomainContentResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\DomainContentResolver\\:\\:makeDomainContentTypeName\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\DomainContentResolver\:\:resolveDomainContentType\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/lib/Resolver/DomainContentResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\DomainContentResolver\\:\\:resolveDomainContentItem\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\DomainContentResolver\:\:resolveDomainRelationFieldValue\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/lib/Resolver/DomainContentResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\DomainContentResolver\\:\\:resolveDomainContentItems\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\DomainContentResolver\:\:resolveDomainRelationFieldValue\(\) has parameter \$multiple with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Resolver/DomainContentResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\DomainContentResolver\\:\\:resolveDomainContentItems\\(\\) has parameter \\$contentTypeIdentifier with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\DomainContentResolver\:\:resolveMainUrlAlias\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/lib/Resolver/DomainContentResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\DomainContentResolver\\:\\:resolveDomainContentItems\\(\\) has parameter \\$query with no type specified\\.$#"
+			message: '#^Parameter \#1 \$locationId of method Ibexa\\Contracts\\Core\\Repository\\LocationService\:\:loadLocation\(\) expects int, int\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/lib/Resolver/DomainContentResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\DomainContentResolver\\:\\:resolveDomainContentType\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/DomainContentResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\DomainContentResolver\\:\\:resolveDomainRelationFieldValue\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/DomainContentResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\DomainContentResolver\\:\\:resolveDomainRelationFieldValue\\(\\) has parameter \\$multiple with no type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/DomainContentResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\DomainContentResolver\\:\\:resolveMainUrlAlias\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/DomainContentResolver.php
-
-		-
-			message: "#^Parameter \\#1 \\$locationId of method Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\LocationService\\:\\:loadLocation\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: src/lib/Resolver/DomainContentResolver.php
-
-		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Resolver\\\\DomainContentResolver\\:\\:\\$queryMapper \\(Ibexa\\\\GraphQL\\\\Resolver\\\\SearchQueryMapper\\) does not accept Ibexa\\\\GraphQL\\\\InputMapper\\\\QueryMapper\\.$#"
-			count: 1
-			path: src/lib/Resolver/DomainContentResolver.php
-
-		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Resolver\\\\DomainContentResolver\\:\\:\\$queryMapper has unknown class Ibexa\\\\GraphQL\\\\Resolver\\\\SearchQueryMapper as its type\\.$#"
-			count: 1
-			path: src/lib/Resolver/DomainContentResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\FieldDefinitionResolver\\:\\:resolveFieldDefinitionDescription\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\FieldDefinitionResolver\:\:resolveFieldDefinitionDescription\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/lib/Resolver/FieldDefinitionResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\FieldDefinitionResolver\\:\\:resolveFieldDefinitionDescription\\(\\) has parameter \\$args with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\FieldDefinitionResolver\:\:resolveFieldDefinitionDescription\(\) has parameter \$args with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Resolver/FieldDefinitionResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\FieldDefinitionResolver\\:\\:resolveFieldDefinitionName\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\FieldDefinitionResolver\:\:resolveFieldDefinitionName\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/lib/Resolver/FieldDefinitionResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\FieldDefinitionResolver\\:\\:resolveFieldDefinitionName\\(\\) has parameter \\$args with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\FieldDefinitionResolver\:\:resolveFieldDefinitionName\(\) has parameter \$args with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Resolver/FieldDefinitionResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\FieldDefinitionResolver\\:\\:resolveSelectionFieldDefinitionOptions\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\FieldDefinitionResolver\:\:resolveSelectionFieldDefinitionOptions\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Resolver/FieldDefinitionResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\FieldDefinitionResolver\\:\\:resolveSelectionFieldDefinitionOptions\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Resolver/FieldDefinitionResolver.php
-
-		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Resolver\\\\ImageAssetFieldResolver\\:\\:\\$strategies has no type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/ImageAssetFieldResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ImageFieldResolver\\:\\:decomposeImageId\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\ImageFieldResolver\:\:decomposeImageId\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Resolver/ImageFieldResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ImageFieldResolver\\:\\:getImageField\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\ImageFieldResolver\:\:resolveImageVariation\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/lib/Resolver/ImageFieldResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ImageFieldResolver\\:\\:resolveImageVariation\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\ImageFieldResolver\:\:resolveImageVariations\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/lib/Resolver/ImageFieldResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ImageFieldResolver\\:\\:resolveImageVariation\\(\\) has parameter \\$args with no type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/ImageFieldResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ImageFieldResolver\\:\\:resolveImageVariations\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/ImageFieldResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ImageFieldResolver\\:\\:resolveImageVariations\\(\\) has parameter \\$args with no type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/ImageFieldResolver.php
-
-		-
-			message: "#^PHPDoc tag @return has invalid value \\(\\[Content, Field\\]\\)\\: Unexpected token \"\\[\", expected type at offset 19$#"
-			count: 1
-			path: src/lib/Resolver/ImageFieldResolver.php
-
-		-
-			message: "#^PHPDoc tag @var has invalid value \\(\\$field \\\\Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Field\\)\\: Unexpected token \"\\$field\", expected type at offset 9$#"
-			count: 1
-			path: src/lib/Resolver/ImageFieldResolver.php
-
-		-
-			message: "#^Variable \\$field might not be defined\\.$#"
+			message: '#^Variable \$field might not be defined\.$#'
+			identifier: variable.undefined
 			count: 3
 			path: src/lib/Resolver/ImageFieldResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ItemResolver\\:\\:resolveItem\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\ItemResolver\:\:resolveItem\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Resolver/ItemResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ItemResolver\\:\\:resolveItemFieldValue\\(\\) has parameter \\$args with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\ItemResolver\:\:resolveItemFieldValue\(\) has parameter \$args with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Resolver/ItemResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ItemResolver\\:\\:resolveItemFieldValue\\(\\) has parameter \\$fieldDefinitionIdentifier with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\ItemResolver\:\:resolveItemOfType\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Resolver/ItemResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ItemResolver\\:\\:resolveItemOfType\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Resolver/ItemResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ItemResolver\\:\\:resolveItemsOfTypeAsConnection\\(\\) has parameter \\$args with no type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/ItemResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\LocationGuesser\\\\FilterLocationGuesser\\:\\:__construct\\(\\) has parameter \\$filters with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\LocationGuesser\\FilterLocationGuesser\:\:__construct\(\) has parameter \$filters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Resolver/LocationGuesser/FilterLocationGuesser.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\LocationGuesser\\\\LocationGuess\\:\\:__construct\\(\\) has parameter \\$locations with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\LocationGuesser\\LocationGuess\:\:__construct\(\) has parameter \$locations with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Resolver/LocationGuesser/LocationGuess.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\LocationGuesser\\\\ObjectStorageLocationList\\:\\:getLocation\\(\\) should return Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location but returns object\\|false\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\LocationGuesser\\ObjectStorageLocationList\:\:getLocation\(\) should return Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Location but returns object\|false\.$#'
+			identifier: return.type
 			count: 1
 			path: src/lib/Resolver/LocationGuesser/ObjectStorageLocationList.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\LocationGuesser\\\\ObjectStorageLocationList\\:\\:getLocations\\(\\) should return array\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location\\> but returns array\\<int, object\\>\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\LocationGuesser\\ObjectStorageLocationList\:\:getLocations\(\) should return array\<Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Location\> but returns array\<int, object\>\.$#'
+			identifier: return.type
 			count: 1
 			path: src/lib/Resolver/LocationGuesser/ObjectStorageLocationList.php
 
 		-
-			message: "#^Parameter \\#2 \\$locations of class Ibexa\\\\GraphQL\\\\Exception\\\\MultipleValidLocationsException constructor expects array\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location\\>, array\\<int, object\\> given\\.$#"
+			message: '#^Parameter \#2 \$locations of class Ibexa\\GraphQL\\Exception\\MultipleValidLocationsException constructor expects array\<Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Location\>, array\<int, object\> given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/lib/Resolver/LocationGuesser/ObjectStorageLocationList.php
 
 		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Resolver\\\\LocationGuesser\\\\ObjectStorageLocationList\\:\\:\\$locations with generic class SplObjectStorage does not specify its types\\: TObject, TData$#"
+			message: '#^Property Ibexa\\GraphQL\\Resolver\\LocationGuesser\\ObjectStorageLocationList\:\:\$locations with generic class SplObjectStorage does not specify its types\: TObject, TData$#'
+			identifier: missingType.generics
 			count: 1
 			path: src/lib/Resolver/LocationGuesser/ObjectStorageLocationList.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\LocationGuesser\\\\TreeRootLocationFilter\\:\\:containsRootPath\\(\\) has parameter \\$path with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\LocationGuesser\\TreeRootLocationFilter\:\:containsRootPath\(\) has parameter \$path with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Resolver/LocationGuesser/TreeRootLocationFilter.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\LocationGuesser\\\\TreeRootLocationFilter\\:\\:containsRootPath\\(\\) has parameter \\$rootPath with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\LocationGuesser\\TreeRootLocationFilter\:\:containsRootPath\(\) has parameter \$rootPath with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Resolver/LocationGuesser/TreeRootLocationFilter.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\LocationResolver\\:\\:resolveLocation\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\LocationResolver\:\:resolveLocation\(\) has parameter \$args with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Resolver/LocationResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\LocationResolver\\:\\:resolveLocation\\(\\) has parameter \\$args with no type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/LocationResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\LocationResolver\\:\\:resolveLocationById\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/LocationResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\LocationResolver\\:\\:resolveLocationById\\(\\) has parameter \\$locationId with no type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/LocationResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\LocationResolver\\:\\:resolveLocationsByContentId\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/LocationResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\LocationResolver\\:\\:resolveLocationsByContentId\\(\\) has parameter \\$contentId with no type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/LocationResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ObjectStateGroupResolver\\:\\:resolveObjectStateGroups\\(\\) should return array\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\ObjectState\\\\ObjectStateGroup\\> but returns iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\ObjectState\\\\ObjectStateGroup\\>\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\ObjectStateGroupResolver\:\:resolveObjectStateGroups\(\) should return array\<Ibexa\\Contracts\\Core\\Repository\\Values\\ObjectState\\ObjectStateGroup\> but returns iterable\<Ibexa\\Contracts\\Core\\Repository\\Values\\ObjectState\\ObjectStateGroup\>\.$#'
+			identifier: return.type
 			count: 1
 			path: src/lib/Resolver/ObjectStateGroupResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ObjectStateResolver\\:\\:resolveObjectStatesByGroup\\(\\) should return array\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\ObjectState\\\\ObjectState\\> but returns iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\ObjectState\\\\ObjectState\\>\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\ObjectStateResolver\:\:resolveObjectStatesByGroup\(\) should return array\<Ibexa\\Contracts\\Core\\Repository\\Values\\ObjectState\\ObjectState\> but returns iterable\<Ibexa\\Contracts\\Core\\Repository\\Values\\ObjectState\\ObjectState\>\.$#'
+			identifier: return.type
 			count: 1
 			path: src/lib/Resolver/ObjectStateResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ObjectStateResolver\\:\\:resolveObjectStatesByGroupId\\(\\) should return array\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\ObjectState\\\\ObjectState\\> but returns iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\ObjectState\\\\ObjectState\\>\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\ObjectStateResolver\:\:resolveObjectStatesByGroupId\(\) should return array\<Ibexa\\Contracts\\Core\\Repository\\Values\\ObjectState\\ObjectState\> but returns iterable\<Ibexa\\Contracts\\Core\\Repository\\Values\\ObjectState\\ObjectState\>\.$#'
+			identifier: return.type
 			count: 1
 			path: src/lib/Resolver/ObjectStateResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\RelationFieldResolver\\:\\:getContentIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\RelationFieldResolver\:\:getContentIds\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Resolver/RelationFieldResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\RelationFieldResolver\\:\\:resolveRelationFieldValue\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\RelationFieldResolver\:\:resolveRelationFieldValue\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/lib/Resolver/RelationFieldResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\RelationFieldResolver\\:\\:resolveRelationFieldValue\\(\\) has parameter \\$multiple with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\RelationFieldResolver\:\:resolveRelationFieldValue\(\) has parameter \$multiple with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Resolver/RelationFieldResolver.php
 
 		-
-			message: "#^Ternary operator condition is always true\\.$#"
+			message: '#^Ternary operator condition is always true\.$#'
+			identifier: ternary.alwaysTrue
 			count: 1
 			path: src/lib/Resolver/RelationFieldResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\RichTextResolver\\:\\:xmlToHtml5\\(\\) has no return type specified\\.$#"
+			message: '#^Parameter \#1 \$string of function strip_tags expects string, string\|false given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/lib/Resolver/RichTextResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\RichTextResolver\\:\\:xmlToHtml5Edit\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/RichTextResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\RichTextResolver\\:\\:xmlToPlainText\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/RichTextResolver.php
-
-		-
-			message: "#^Parameter \\#1 \\$string of function strip_tags expects string, string\\|false given\\.$#"
-			count: 1
-			path: src/lib/Resolver/RichTextResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\SearchResolver\\:\\:searchContent\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/SearchResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\SearchResolver\\:\\:searchContent\\(\\) has parameter \\$args with no type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/SearchResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\SearchResolver\\:\\:searchContentOfTypeAsConnection\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/SearchResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\SearchResolver\\:\\:searchContentOfTypeAsConnection\\(\\) has parameter \\$args with no type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/SearchResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\SearchResolver\\:\\:searchContentOfTypeAsConnection\\(\\) has parameter \\$contentTypeIdentifier with no type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/SearchResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\SectionResolver\\:\\:resolveSectionById\\(\\) has parameter \\$sectionId with no type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/SectionResolver.php
-
-		-
-			message: "#^Cannot call method getFieldSettings\\(\\) on Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\ContentType\\\\FieldDefinition\\|null\\.$#"
+			message: '#^Cannot call method getFieldSettings\(\) on Ibexa\\Contracts\\Core\\Repository\\Values\\ContentType\\FieldDefinition\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/lib/Resolver/SelectionFieldResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\SelectionFieldResolver\\:\\:getOptions\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\SelectionFieldResolver\:\:getOptions\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Resolver/SelectionFieldResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\SelectionFieldResolver\\:\\:resolveSelectionFieldValue\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\SelectionFieldResolver\:\:resolveSelectionFieldValue\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/lib/Resolver/SelectionFieldResolver.php
 
 		-
-			message: "#^Parameter \\#3 \\$fieldDefinition of method Ibexa\\\\GraphQL\\\\Resolver\\\\SelectionFieldResolver\\:\\:getOptions\\(\\) expects Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\ContentType\\\\FieldDefinition, Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\ContentType\\\\FieldDefinition\\|null given\\.$#"
+			message: '#^Parameter \#3 \$fieldDefinition of method Ibexa\\GraphQL\\Resolver\\SelectionFieldResolver\:\:getOptions\(\) expects Ibexa\\Contracts\\Core\\Repository\\Values\\ContentType\\FieldDefinition, Ibexa\\Contracts\\Core\\Repository\\Values\\ContentType\\FieldDefinition\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/lib/Resolver/SelectionFieldResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\SiteaccessGuesser\\\\SiteaccessGuesser\\:\\:__construct\\(\\) has parameter \\$siteAccessGroups with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\SiteaccessGuesser\\SiteaccessGuesser\:\:__construct\(\) has parameter \$siteAccessGroups with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Resolver/SiteaccessGuesser/SiteaccessGuesser.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\SiteaccessGuesser\\\\SiteaccessGuesser\\:\\:guessForLocation\\(\\) should return Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess but returns Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess\\|null\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\SiteaccessGuesser\\SiteaccessGuesser\:\:guessForLocation\(\) should return Ibexa\\Core\\MVC\\Symfony\\SiteAccess but returns Ibexa\\Core\\MVC\\Symfony\\SiteAccess\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: src/lib/Resolver/SiteaccessGuesser/SiteaccessGuesser.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\SiteaccessGuesser\\\\SiteaccessGuesser\\:\\:isAdminSiteaccess\\(\\) has no return type specified\\.$#"
+			message: '#^Property Ibexa\\GraphQL\\Resolver\\SiteaccessGuesser\\SiteaccessGuesser\:\:\$siteAccessGroups type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Resolver/SiteaccessGuesser/SiteaccessGuesser.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\SiteaccessGuesser\\\\SiteaccessGuesser\\:\\:isInSubtree\\(\\) should return int\\|false but returns int\\|string\\|false\\.$#"
+			message: '#^Variable \$saList in PHPDoc tag @var does not match assigned variable \$matchingSiteaccessRootDepth\.$#'
+			identifier: varTag.differentVariable
 			count: 1
 			path: src/lib/Resolver/SiteaccessGuesser/SiteaccessGuesser.php
 
 		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Resolver\\\\SiteaccessGuesser\\\\SiteaccessGuesser\\:\\:\\$siteAccessGroups type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Resolver/SiteaccessGuesser/SiteaccessGuesser.php
-
-		-
-			message: "#^Variable \\$saList in PHPDoc tag @var does not match assigned variable \\$matchingSiteaccessRootDepth\\.$#"
-			count: 1
-			path: src/lib/Resolver/SiteaccessGuesser/SiteaccessGuesser.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\ThumbnailResolver\\:\\:resolveThumbnail\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\ThumbnailResolver\:\:resolveThumbnail\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Resolver/ThumbnailResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\UrlAliasResolver\\:\\:resolveLocationUrlAliases\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/UrlAliasResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\UrlAliasResolver\\:\\:resolveLocationUrlAliases\\(\\) has parameter \\$args with no type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/UrlAliasResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\UrlAliasResolver\\:\\:resolveUrlAliasType\\(\\) should return string but returns GraphQL\\\\Type\\\\Definition\\\\Type\\|null\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Resolver\\UrlAliasResolver\:\:resolveUrlAliasType\(\) should return string but returns GraphQL\\Type\\Definition\\Type\|null\.$#'
+			identifier: return.type
 			count: 3
 			path: src/lib/Resolver/UrlAliasResolver.php
 
 		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Resolver\\\\UrlAliasResolver\\:\\:\\$configResolver is never read, only written\\.$#"
+			message: '#^Property Ibexa\\GraphQL\\Resolver\\UrlAliasResolver\:\:\$configResolver is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: src/lib/Resolver/UrlAliasResolver.php
 
 		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Resolver\\\\UrlAliasResolver\\:\\:\\$locationService is never read, only written\\.$#"
+			message: '#^Property Ibexa\\GraphQL\\Resolver\\UrlAliasResolver\:\:\$locationService is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: src/lib/Resolver/UrlAliasResolver.php
 
 		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Resolver\\\\UrlAliasResolver\\:\\:\\$siteaccessService \\(Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess\\\\SiteAccessService\\) does not accept Ibexa\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess\\\\SiteAccessServiceInterface\\.$#"
+			message: '#^Property Ibexa\\GraphQL\\Resolver\\UrlAliasResolver\:\:\$siteaccessService \(Ibexa\\Core\\MVC\\Symfony\\SiteAccess\\SiteAccessService\) does not accept Ibexa\\Core\\MVC\\Symfony\\SiteAccess\\SiteAccessServiceInterface\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: src/lib/Resolver/UrlAliasResolver.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\UserResolver\\:\\:resolveContentFields\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/UserResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\UserResolver\\:\\:resolveContentFields\\(\\) has parameter \\$args with no type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/UserResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\UserResolver\\:\\:resolveUser\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/UserResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\UserResolver\\:\\:resolveUser\\(\\) has parameter \\$args with no type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/UserResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\UserResolver\\:\\:resolveUserById\\(\\) has parameter \\$userId with no type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/UserResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\UserResolver\\:\\:resolveUserGroupById\\(\\) has parameter \\$userGroupId with no type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/UserResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\UserResolver\\:\\:resolveUserGroupSubGroups\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/UserResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\UserResolver\\:\\:resolveUserGroups\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/UserResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\UserResolver\\:\\:resolveUserGroups\\(\\) has parameter \\$args with no type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/UserResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\UserResolver\\:\\:resolveUserGroupsByUserId\\(\\) has parameter \\$userId with no type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/UserResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\UserResolver\\:\\:resolveUserGroupsByUserId\\(\\) should return array\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\User\\\\UserGroup\\> but returns iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\User\\\\UserGroup\\>\\.$#"
-			count: 1
-			path: src/lib/Resolver/UserResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Resolver\\\\UserResolver\\:\\:resolveUsersOfGroup\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Resolver/UserResolver.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\:\\:addArgToField\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Builder\:\:addArgToField\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/lib/Schema/Builder.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\:\\:addFieldToType\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Builder\:\:addFieldToType\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/lib/Schema/Builder.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\:\\:addType\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Builder\:\:addType\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/lib/Schema/Builder.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\:\\:addValueToEnum\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Builder\:\:addValueToEnum\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/lib/Schema/Builder.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\:\\:getSchema\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Builder\:\:getSchema\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Builder.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\:\\:hasTypeFieldWithArg\\(\\) has parameter \\$arg with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Builder\:\:hasTypeFieldWithArg\(\) has parameter \$arg with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Schema/Builder.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\Input\\\\Arg\\:\\:__construct\\(\\) has parameter \\$name with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Builder\\Input\\Arg\:\:__construct\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Schema/Builder/Input/Arg.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\Input\\\\Arg\\:\\:__construct\\(\\) has parameter \\$properties with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Builder\\Input\\Arg\:\:__construct\(\) has parameter \$properties with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Builder/Input/Arg.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\Input\\\\Arg\\:\\:__construct\\(\\) has parameter \\$type with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Builder\\Input\\Arg\:\:__construct\(\) has parameter \$type with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Schema/Builder/Input/Arg.php
 
 		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\Input\\\\Arg\\:\\:\\$defaultValue has no type specified\\.$#"
+			message: '#^Property Ibexa\\GraphQL\\Schema\\Builder\\Input\\Arg\:\:\$defaultValue has no type specified\.$#'
+			identifier: missingType.property
 			count: 1
 			path: src/lib/Schema/Builder/Input/Arg.php
 
 		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\Input\\\\Arg\\:\\:\\$description has no type specified\\.$#"
+			message: '#^Property Ibexa\\GraphQL\\Schema\\Builder\\Input\\Arg\:\:\$description has no type specified\.$#'
+			identifier: missingType.property
 			count: 1
 			path: src/lib/Schema/Builder/Input/Arg.php
 
 		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\Input\\\\Arg\\:\\:\\$name has no type specified\\.$#"
+			message: '#^Property Ibexa\\GraphQL\\Schema\\Builder\\Input\\Arg\:\:\$name has no type specified\.$#'
+			identifier: missingType.property
 			count: 1
 			path: src/lib/Schema/Builder/Input/Arg.php
 
 		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\Input\\\\Arg\\:\\:\\$type has no type specified\\.$#"
+			message: '#^Property Ibexa\\GraphQL\\Schema\\Builder\\Input\\Arg\:\:\$type has no type specified\.$#'
+			identifier: missingType.property
 			count: 1
 			path: src/lib/Schema/Builder/Input/Arg.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\Input\\\\EnumValue\\:\\:__construct\\(\\) has parameter \\$name with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Builder\\Input\\EnumValue\:\:__construct\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Schema/Builder/Input/EnumValue.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\Input\\\\EnumValue\\:\\:__construct\\(\\) has parameter \\$properties with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Builder\\Input\\EnumValue\:\:__construct\(\) has parameter \$properties with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Builder/Input/EnumValue.php
 
 		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\Input\\\\EnumValue\\:\\:\\$description has no type specified\\.$#"
+			message: '#^Property Ibexa\\GraphQL\\Schema\\Builder\\Input\\EnumValue\:\:\$description has no type specified\.$#'
+			identifier: missingType.property
 			count: 1
 			path: src/lib/Schema/Builder/Input/EnumValue.php
 
 		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\Input\\\\EnumValue\\:\\:\\$name has no type specified\\.$#"
+			message: '#^Property Ibexa\\GraphQL\\Schema\\Builder\\Input\\EnumValue\:\:\$name has no type specified\.$#'
+			identifier: missingType.property
 			count: 1
 			path: src/lib/Schema/Builder/Input/EnumValue.php
 
 		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\Input\\\\EnumValue\\:\\:\\$value has no type specified\\.$#"
+			message: '#^Property Ibexa\\GraphQL\\Schema\\Builder\\Input\\EnumValue\:\:\$value has no type specified\.$#'
+			identifier: missingType.property
 			count: 1
 			path: src/lib/Schema/Builder/Input/EnumValue.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\Input\\\\Field\\:\\:__construct\\(\\) has parameter \\$name with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Builder\\Input\\Field\:\:__construct\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Schema/Builder/Input/Field.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\Input\\\\Field\\:\\:__construct\\(\\) has parameter \\$properties with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Builder\\Input\\Field\:\:__construct\(\) has parameter \$properties with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Builder/Input/Field.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\Input\\\\Field\\:\\:__construct\\(\\) has parameter \\$type with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Builder\\Input\\Field\:\:__construct\(\) has parameter \$type with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Schema/Builder/Input/Field.php
 
 		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\Input\\\\Field\\:\\:\\$argsBuilder has no type specified\\.$#"
+			message: '#^Property Ibexa\\GraphQL\\Schema\\Builder\\Input\\Field\:\:\$argsBuilder has no type specified\.$#'
+			identifier: missingType.property
 			count: 1
 			path: src/lib/Schema/Builder/Input/Field.php
 
 		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\Input\\\\Field\\:\\:\\$description has no type specified\\.$#"
+			message: '#^Property Ibexa\\GraphQL\\Schema\\Builder\\Input\\Field\:\:\$description has no type specified\.$#'
+			identifier: missingType.property
 			count: 1
 			path: src/lib/Schema/Builder/Input/Field.php
 
 		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\Input\\\\Field\\:\\:\\$name has no type specified\\.$#"
+			message: '#^Property Ibexa\\GraphQL\\Schema\\Builder\\Input\\Field\:\:\$name has no type specified\.$#'
+			identifier: missingType.property
 			count: 1
 			path: src/lib/Schema/Builder/Input/Field.php
 
 		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\Input\\\\Field\\:\\:\\$resolve has no type specified\\.$#"
+			message: '#^Property Ibexa\\GraphQL\\Schema\\Builder\\Input\\Field\:\:\$resolve has no type specified\.$#'
+			identifier: missingType.property
 			count: 1
 			path: src/lib/Schema/Builder/Input/Field.php
 
 		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\Input\\\\Field\\:\\:\\$type has no type specified\\.$#"
+			message: '#^Property Ibexa\\GraphQL\\Schema\\Builder\\Input\\Field\:\:\$type has no type specified\.$#'
+			identifier: missingType.property
 			count: 1
 			path: src/lib/Schema/Builder/Input/Field.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\Input\\\\Input\\:\\:__construct\\(\\) has parameter \\$properties with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Builder\\Input\\Input\:\:__construct\(\) has parameter \$properties with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Builder/Input/Input.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\Input\\\\Type\\:\\:__construct\\(\\) has parameter \\$name with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Builder\\Input\\Type\:\:__construct\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Schema/Builder/Input/Type.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\Input\\\\Type\\:\\:__construct\\(\\) has parameter \\$properties with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Builder\\Input\\Type\:\:__construct\(\) has parameter \$properties with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Builder/Input/Type.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\Input\\\\Type\\:\\:__construct\\(\\) has parameter \\$type with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Builder\\Input\\Type\:\:__construct\(\) has parameter \$type with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Schema/Builder/Input/Type.php
 
 		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\Input\\\\Type\\:\\:\\$connectionFields has no type specified\\.$#"
+			message: '#^Property Ibexa\\GraphQL\\Schema\\Builder\\Input\\Type\:\:\$connectionFields has no type specified\.$#'
+			identifier: missingType.property
 			count: 1
 			path: src/lib/Schema/Builder/Input/Type.php
 
 		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\Input\\\\Type\\:\\:\\$inherits has no type specified\\.$#"
+			message: '#^Property Ibexa\\GraphQL\\Schema\\Builder\\Input\\Type\:\:\$inherits has no type specified\.$#'
+			identifier: missingType.property
 			count: 1
 			path: src/lib/Schema/Builder/Input/Type.php
 
 		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\Input\\\\Type\\:\\:\\$interfaces has no type specified\\.$#"
+			message: '#^Property Ibexa\\GraphQL\\Schema\\Builder\\Input\\Type\:\:\$interfaces has no type specified\.$#'
+			identifier: missingType.property
 			count: 1
 			path: src/lib/Schema/Builder/Input/Type.php
 
 		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\Input\\\\Type\\:\\:\\$name has no type specified\\.$#"
+			message: '#^Property Ibexa\\GraphQL\\Schema\\Builder\\Input\\Type\:\:\$name has no type specified\.$#'
+			identifier: missingType.property
 			count: 1
 			path: src/lib/Schema/Builder/Input/Type.php
 
 		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\Input\\\\Type\\:\\:\\$nodeType has no type specified\\.$#"
+			message: '#^Property Ibexa\\GraphQL\\Schema\\Builder\\Input\\Type\:\:\$nodeType has no type specified\.$#'
+			identifier: missingType.property
 			count: 1
 			path: src/lib/Schema/Builder/Input/Type.php
 
 		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\Input\\\\Type\\:\\:\\$type has no type specified\\.$#"
+			message: '#^Property Ibexa\\GraphQL\\Schema\\Builder\\Input\\Type\:\:\$type has no type specified\.$#'
+			identifier: missingType.property
 			count: 1
 			path: src/lib/Schema/Builder/Input/Type.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\SchemaBuilder\\:\\:addArgToField\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Builder\\SchemaBuilder\:\:getSchema\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Builder/SchemaBuilder.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\SchemaBuilder\\:\\:addFieldToType\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Builder\\SchemaBuilder\:\:hasTypeFieldWithArg\(\) has parameter \$arg with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Schema/Builder/SchemaBuilder.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\SchemaBuilder\\:\\:addType\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Builder/SchemaBuilder.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\SchemaBuilder\\:\\:addValueToEnum\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Builder/SchemaBuilder.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\SchemaBuilder\\:\\:getSchema\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Schema/Builder/SchemaBuilder.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\SchemaBuilder\\:\\:hasTypeFieldWithArg\\(\\) has parameter \\$arg with no type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Builder/SchemaBuilder.php
-
-		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Schema\\\\Builder\\\\SchemaBuilder\\:\\:\\$schema has no type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Builder/SchemaBuilder.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\ContentDomainIterator\\:\\:init\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/ContentDomainIterator.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\LanguagesIterator\\:\\:init\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/LanguagesIterator.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Mapper\\\\FieldDefinition\\\\ConfigurableFieldDefinitionMapper\\:\\:__construct\\(\\) has parameter \\$typesMap with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Mapper\\FieldDefinition\\ConfigurableFieldDefinitionMapper\:\:__construct\(\) has parameter \$typesMap with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Schema/Domain/Content/Mapper/FieldDefinition/ConfigurableFieldDefinitionMapper.php
 
 		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Mapper\\\\FieldDefinition\\\\ConfigurableFieldDefinitionMapper\\:\\:\\$typesMap type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Ibexa\\GraphQL\\Schema\\Domain\\Content\\Mapper\\FieldDefinition\\ConfigurableFieldDefinitionMapper\:\:\$typesMap type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Domain/Content/Mapper/FieldDefinition/ConfigurableFieldDefinitionMapper.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Mapper\\\\FieldDefinition\\\\DecoratingFieldDefinitionMapper\\:\\:canMap\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Mapper\\FieldDefinition\\DecoratingFieldDefinitionMapper\:\:canMap\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/lib/Schema/Domain/Content/Mapper/FieldDefinition/DecoratingFieldDefinitionMapper.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Mapper\\\\FieldDefinition\\\\RelationFieldDefinitionMapper\\:\\:canMap\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Mapper/FieldDefinition/RelationFieldDefinitionMapper.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Mapper\\\\FieldDefinition\\\\RelationFieldDefinitionMapper\\:\\:isMultiple\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Mapper/FieldDefinition/RelationFieldDefinitionMapper.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Mapper\\\\FieldDefinition\\\\ResolverVariables\\:\\:mapToFieldDefinitionType\\(\\) should return string but returns string\\|null\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Mapper\\FieldDefinition\\ResolverVariables\:\:mapToFieldDefinitionType\(\) should return string but returns string\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: src/lib/Schema/Domain/Content/Mapper/FieldDefinition/ResolverVariables.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Mapper\\\\FieldDefinition\\\\ResolverVariables\\:\\:mapToFieldValueType\\(\\) should return string but returns string\\|null\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Mapper\\FieldDefinition\\ResolverVariables\:\:mapToFieldValueType\(\) should return string but returns string\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: src/lib/Schema/Domain/Content/Mapper/FieldDefinition/ResolverVariables.php
 
 		-
-			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Mapper/FieldDefinition/ResolverVariables.php
-
-		-
-			message: "#^Cannot call method warning\\(\\) on Psr\\\\Log\\\\LoggerInterface\\|null\\.$#"
+			message: '#^Cannot call method warning\(\) on Psr\\Log\\LoggerInterface\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/lib/Schema/Domain/Content/NameHelper.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\NameHelper\\:\\:__construct\\(\\) has parameter \\$fieldNameOverrides with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\NameHelper\:\:__construct\(\) has parameter \$fieldNameOverrides with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Domain/Content/NameHelper.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\NameHelper\\:\\:fieldDefinitionField\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\NameHelper\:\:itemConnectionName\(\) has parameter \$contentType with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Schema/Domain/Content/NameHelper.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\NameHelper\\:\\:itemConnectionField\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\NameHelper\:\:sanitizeContentTypeGroupIdentifier\(\) should return string but returns string\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: src/lib/Schema/Domain/Content/NameHelper.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\NameHelper\\:\\:itemConnectionName\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/NameHelper.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\NameHelper\\:\\:itemConnectionName\\(\\) has parameter \\$contentType with no type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/NameHelper.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\NameHelper\\:\\:itemCreateInputName\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/NameHelper.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\NameHelper\\:\\:itemField\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/NameHelper.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\NameHelper\\:\\:itemGroupField\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/NameHelper.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\NameHelper\\:\\:itemGroupName\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/NameHelper.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\NameHelper\\:\\:itemGroupTypesName\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/NameHelper.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\NameHelper\\:\\:itemMutationCreateItemField\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/NameHelper.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\NameHelper\\:\\:itemMutationUpdateItemField\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/NameHelper.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\NameHelper\\:\\:itemMutationUpdateItemField\\(\\) has parameter \\$contentType with no type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/NameHelper.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\NameHelper\\:\\:itemName\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/NameHelper.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\NameHelper\\:\\:itemTypeName\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/NameHelper.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\NameHelper\\:\\:itemUpdateInputName\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/NameHelper.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\NameHelper\\:\\:sanitizeContentTypeGroupIdentifier\\(\\) should return string but returns string\\|null\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/NameHelper.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\BaseWorker\\:\\:getNameHelper\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Worker\\BaseWorker\:\:getNameHelper\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/lib/Schema/Domain/Content/Worker/BaseWorker.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\BaseWorker\\:\\:setNameHelper\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/BaseWorker.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\AddItemOfTypeConnectionToGroup\\:\\:canWork\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentType/AddItemOfTypeConnectionToGroup.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\AddItemOfTypeConnectionToGroup\\:\\:connectionField\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentType/AddItemOfTypeConnectionToGroup.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\AddItemOfTypeConnectionToGroup\\:\\:connectionType\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentType/AddItemOfTypeConnectionToGroup.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\AddItemOfTypeConnectionToGroup\\:\\:groupName\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentType/AddItemOfTypeConnectionToGroup.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\AddItemOfTypeConnectionToGroup\\:\\:typeName\\(\\) has parameter \\$args with no type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentType/AddItemOfTypeConnectionToGroup.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\AddItemOfTypeConnectionToGroup\\:\\:work\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentType/AddItemOfTypeConnectionToGroup.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\AddItemOfTypeConnectionToGroup\\:\\:work\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentType/AddItemOfTypeConnectionToGroup.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\AddItemToGroup\\:\\:canWork\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentType/AddItemToGroup.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\AddItemToGroup\\:\\:groupName\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentType/AddItemToGroup.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\AddItemToGroup\\:\\:typeField\\(\\) has parameter \\$args with no type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentType/AddItemToGroup.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\AddItemToGroup\\:\\:typeName\\(\\) has parameter \\$args with no type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentType/AddItemToGroup.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\AddItemToGroup\\:\\:work\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentType/AddItemToGroup.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\AddItemToGroup\\:\\:work\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentType/AddItemToGroup.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\AddItemTypeToItemGroupTypes\\:\\:canWork\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Worker\\ContentType\\AddItemTypeToItemGroupTypes\:\:canWork\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Domain/Content/Worker/ContentType/AddItemTypeToItemGroupTypes.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\AddItemTypeToItemGroupTypes\\:\\:groupTypesName\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Worker\\ContentType\\AddItemTypeToItemGroupTypes\:\:groupTypesName\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Domain/Content/Worker/ContentType/AddItemTypeToItemGroupTypes.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\AddItemTypeToItemGroupTypes\\:\\:typeField\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Worker\\ContentType\\AddItemTypeToItemGroupTypes\:\:typeField\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Domain/Content/Worker/ContentType/AddItemTypeToItemGroupTypes.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\AddItemTypeToItemGroupTypes\\:\\:typeName\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Worker\\ContentType\\AddItemTypeToItemGroupTypes\:\:typeName\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Domain/Content/Worker/ContentType/AddItemTypeToItemGroupTypes.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\AddItemTypeToItemGroupTypes\\:\\:work\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Worker\\ContentType\\AddItemTypeToItemGroupTypes\:\:work\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Domain/Content/Worker/ContentType/AddItemTypeToItemGroupTypes.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\AddItemTypeToItemGroupTypes\\:\\:work\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentType/AddItemTypeToItemGroupTypes.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\AddItemTypeToItemTypeIdentifierList\\:\\:canWork\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Worker\\ContentType\\AddItemTypeToItemTypeIdentifierList\:\:canWork\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Domain/Content/Worker/ContentType/AddItemTypeToItemTypeIdentifierList.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\AddItemTypeToItemTypeIdentifierList\\:\\:init\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Worker\\ContentType\\AddItemTypeToItemTypeIdentifierList\:\:work\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Domain/Content/Worker/ContentType/AddItemTypeToItemTypeIdentifierList.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\AddItemTypeToItemTypeIdentifierList\\:\\:work\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentType/AddItemTypeToItemTypeIdentifierList.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\AddItemTypeToItemTypeIdentifierList\\:\\:work\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentType/AddItemTypeToItemTypeIdentifierList.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\DefineItem\\:\\:canWork\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Worker\\ContentType\\DefineItem\:\:canWork\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Domain/Content/Worker/ContentType/DefineItem.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\DefineItem\\:\\:typeName\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Worker\\ContentType\\DefineItem\:\:typeName\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Domain/Content/Worker/ContentType/DefineItem.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\DefineItem\\:\\:work\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Worker\\ContentType\\DefineItem\:\:work\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Domain/Content/Worker/ContentType/DefineItem.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\DefineItem\\:\\:work\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentType/DefineItem.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\DefineItemConnection\\:\\:canWork\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentType/DefineItemConnection.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\DefineItemConnection\\:\\:connectionTypeName\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentType/DefineItemConnection.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\DefineItemConnection\\:\\:typeName\\(\\) has parameter \\$args with no type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentType/DefineItemConnection.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\DefineItemConnection\\:\\:work\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentType/DefineItemConnection.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\DefineItemConnection\\:\\:work\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentType/DefineItemConnection.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\DefineItemMutation\\:\\:canWork\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Worker\\ContentType\\DefineItemMutation\:\:canWork\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Domain/Content/Worker/ContentType/DefineItemMutation.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\DefineItemMutation\\:\\:getCreateField\\(\\) has parameter \\$contentType with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Worker\\ContentType\\DefineItemMutation\:\:getCreateField\(\) has parameter \$contentType with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Schema/Domain/Content/Worker/ContentType/DefineItemMutation.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\DefineItemMutation\\:\\:getCreateInputName\\(\\) has parameter \\$contentType with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Worker\\ContentType\\DefineItemMutation\:\:getCreateInputName\(\) has parameter \$contentType with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Schema/Domain/Content/Worker/ContentType/DefineItemMutation.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\DefineItemMutation\\:\\:getUpdateField\\(\\) has parameter \\$contentType with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Worker\\ContentType\\DefineItemMutation\:\:getUpdateField\(\) has parameter \$contentType with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Schema/Domain/Content/Worker/ContentType/DefineItemMutation.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\DefineItemMutation\\:\\:getUpdateInputName\\(\\) has parameter \\$contentType with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Worker\\ContentType\\DefineItemMutation\:\:getUpdateInputName\(\) has parameter \$contentType with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/lib/Schema/Domain/Content/Worker/ContentType/DefineItemMutation.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\DefineItemMutation\\:\\:init\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Worker\\ContentType\\DefineItemMutation\:\:work\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Domain/Content/Worker/ContentType/DefineItemMutation.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\DefineItemMutation\\:\\:work\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentType/DefineItemMutation.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\DefineItemMutation\\:\\:work\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentType/DefineItemMutation.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\DefineItemType\\:\\:canWork\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Worker\\ContentType\\DefineItemType\:\:canWork\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Domain/Content/Worker/ContentType/DefineItemType.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\DefineItemType\\:\\:typeName\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Worker\\ContentType\\DefineItemType\:\:typeName\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Domain/Content/Worker/ContentType/DefineItemType.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\DefineItemType\\:\\:work\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Worker\\ContentType\\DefineItemType\:\:work\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Domain/Content/Worker/ContentType/DefineItemType.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentType\\\\DefineItemType\\:\\:work\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentType/DefineItemType.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentTypeGroup\\\\AddDomainGroupToDomain\\:\\:canWork\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentTypeGroup/AddDomainGroupToDomain.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentTypeGroup\\\\AddDomainGroupToDomain\\:\\:fieldName\\(\\) has parameter \\$args with no type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentTypeGroup/AddDomainGroupToDomain.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentTypeGroup\\\\AddDomainGroupToDomain\\:\\:typeGroupName\\(\\) has parameter \\$args with no type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentTypeGroup/AddDomainGroupToDomain.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentTypeGroup\\\\AddDomainGroupToDomain\\:\\:work\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentTypeGroup/AddDomainGroupToDomain.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentTypeGroup\\\\AddDomainGroupToDomain\\:\\:work\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentTypeGroup/AddDomainGroupToDomain.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentTypeGroup\\\\DefineDomainGroup\\:\\:canWork\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroup.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentTypeGroup\\\\DefineDomainGroup\\:\\:groupTypesName\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroup.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentTypeGroup\\\\DefineDomainGroup\\:\\:typeName\\(\\) has parameter \\$args with no type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroup.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentTypeGroup\\\\DefineDomainGroup\\:\\:work\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroup.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentTypeGroup\\\\DefineDomainGroup\\:\\:work\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroup.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentTypeGroup\\\\DefineDomainGroupTypes\\:\\:canWork\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroupTypes.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentTypeGroup\\\\DefineDomainGroupTypes\\:\\:typeName\\(\\) has parameter \\$args with no type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroupTypes.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentTypeGroup\\\\DefineDomainGroupTypes\\:\\:work\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroupTypes.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\ContentTypeGroup\\\\DefineDomainGroupTypes\\:\\:work\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroupTypes.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\FieldDefinition\\\\AddFieldDefinitionToItemMutation\\:\\:canWork\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Worker\\FieldDefinition\\AddFieldDefinitionToItemMutation\:\:canWork\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToItemMutation.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\FieldDefinition\\\\AddFieldDefinitionToItemMutation\\:\\:mapDescription\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Worker\\FieldDefinition\\AddFieldDefinitionToItemMutation\:\:mapDescription\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToItemMutation.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\FieldDefinition\\\\AddFieldDefinitionToItemMutation\\:\\:nameCreateInputType\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Worker\\FieldDefinition\\AddFieldDefinitionToItemMutation\:\:nameCreateInputType\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToItemMutation.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\FieldDefinition\\\\AddFieldDefinitionToItemMutation\\:\\:nameFieldDefinitionField\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Worker\\FieldDefinition\\AddFieldDefinitionToItemMutation\:\:nameFieldDefinitionField\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToItemMutation.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\FieldDefinition\\\\AddFieldDefinitionToItemMutation\\:\\:nameFieldType\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Worker\\FieldDefinition\\AddFieldDefinitionToItemMutation\:\:nameFieldType\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToItemMutation.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\FieldDefinition\\\\AddFieldDefinitionToItemMutation\\:\\:nameFieldType\\(\\) has parameter \\$operation with no type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Worker\\FieldDefinition\\AddFieldDefinitionToItemMutation\:\:nameUpdateInputType\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToItemMutation.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\FieldDefinition\\\\AddFieldDefinitionToItemMutation\\:\\:nameUpdateInputType\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Worker\\FieldDefinition\\AddFieldDefinitionToItemMutation\:\:work\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToItemMutation.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\FieldDefinition\\\\AddFieldDefinitionToItemMutation\\:\\:work\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToItemMutation.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\FieldDefinition\\\\AddFieldDefinitionToItemMutation\\:\\:work\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToItemMutation.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\FieldDefinition\\\\AddFieldDefinitionToItemType\\:\\:canWork\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Worker\\FieldDefinition\\AddFieldDefinitionToItemType\:\:fieldDescription\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToItemType.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\FieldDefinition\\\\AddFieldDefinitionToItemType\\:\\:fieldDescription\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToItemType.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\FieldDefinition\\\\AddFieldDefinitionToItemType\\:\\:fieldDescription\\(\\) has parameter \\$args with no type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToItemType.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\FieldDefinition\\\\AddFieldDefinitionToItemType\\:\\:fieldName\\(\\) has parameter \\$args with no type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToItemType.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\FieldDefinition\\\\AddFieldDefinitionToItemType\\:\\:fieldType\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToItemType.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\FieldDefinition\\\\AddFieldDefinitionToItemType\\:\\:fieldType\\(\\) has parameter \\$args with no type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToItemType.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\FieldDefinition\\\\AddFieldDefinitionToItemType\\:\\:typeName\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToItemType.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\FieldDefinition\\\\AddFieldDefinitionToItemType\\:\\:work\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToItemType.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\FieldDefinition\\\\AddFieldDefinitionToItemType\\:\\:work\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToItemType.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\FieldDefinition\\\\AddFieldValueToItem\\:\\:canWork\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldValueToItem.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\FieldDefinition\\\\AddFieldValueToItem\\:\\:fieldName\\(\\) has parameter \\$args with no type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldValueToItem.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\FieldDefinition\\\\AddFieldValueToItem\\:\\:getDefinition\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldValueToItem.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\FieldDefinition\\\\AddFieldValueToItem\\:\\:typeName\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldValueToItem.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\FieldDefinition\\\\AddFieldValueToItem\\:\\:work\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldValueToItem.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\FieldDefinition\\\\AddFieldValueToItem\\:\\:work\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldValueToItem.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\Language\\\\AddLanguageToEnum\\:\\:canWork\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Worker\\Language\\AddLanguageToEnum\:\:canWork\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Domain/Content/Worker/Language/AddLanguageToEnum.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\Language\\\\AddLanguageToEnum\\:\\:init\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\Content\\Worker\\Language\\AddLanguageToEnum\:\:work\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Domain/Content/Worker/Language/AddLanguageToEnum.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\Language\\\\AddLanguageToEnum\\:\\:work\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/Language/AddLanguageToEnum.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Content\\\\Worker\\\\Language\\\\AddLanguageToEnum\\:\\:work\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Content/Worker/Language/AddLanguageToEnum.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\ImageVariationDomain\\:\\:canWork\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\ImageVariationDomain\:\:canWork\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Domain/ImageVariationDomain.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\ImageVariationDomain\\:\\:init\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Domain\\ImageVariationDomain\:\:work\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Domain/ImageVariationDomain.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\ImageVariationDomain\\:\\:work\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/ImageVariationDomain.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\ImageVariationDomain\\:\\:work\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/ImageVariationDomain.php
-
-		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Domain\\\\Iterator\\:\\:init\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Schema/Domain/Iterator.php
-
-		-
-			message: "#^PHPDoc tag @return has invalid value \\(\\)\\: Unexpected token \"\\\\n     \", expected type at offset 81$#"
-			count: 1
-			path: src/lib/Schema/Domain/Iterator.php
-
-		-
-			message: "#^Cannot call method warning\\(\\) on Psr\\\\Log\\\\LoggerInterface\\|null\\.$#"
+			message: '#^Cannot call method warning\(\) on Psr\\Log\\LoggerInterface\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/lib/Schema/Domain/NameValidator.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Generator\\:\\:__construct\\(\\) has parameter \\$iterators with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Generator\:\:__construct\(\) has parameter \$iterators with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Generator.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Generator\\:\\:__construct\\(\\) has parameter \\$workers with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Generator\:\:__construct\(\) has parameter \$workers with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Generator.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Generator\\:\\:generate\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Generator\:\:generate\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Generator.php
 
 		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Schema\\\\Generator\\:\\:\\$groups is unused\\.$#"
+			message: '#^Property Ibexa\\GraphQL\\Schema\\Generator\:\:\$groups is unused\.$#'
+			identifier: property.unused
 			count: 1
 			path: src/lib/Schema/Generator.php
 
 		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Schema\\\\Generator\\:\\:\\$groups type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Ibexa\\GraphQL\\Schema\\Generator\:\:\$groups type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Generator.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Initializer\\:\\:init\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Initializer\:\:init\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/lib/Schema/Initializer.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\SchemaBuilder\\:\\:build\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\SchemaBuilder\:\:build\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/lib/Schema/SchemaBuilder.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\SchemaBuilder\\:\\:build\\(\\) has parameter \\$schema with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\SchemaBuilder\:\:build\(\) has parameter \$schema with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/SchemaBuilder.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\SchemaGenerator\\:\\:__construct\\(\\) has parameter \\$schemaBuilders with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\SchemaGenerator\:\:__construct\(\) has parameter \$schemaBuilders with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/SchemaGenerator.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\SchemaGenerator\\:\\:generate\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\SchemaGenerator\:\:generate\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/SchemaGenerator.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Worker\\:\\:canWork\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Worker\:\:canWork\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Worker.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Worker\\:\\:work\\(\\) has no return type specified\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Worker\:\:work\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/lib/Schema/Worker.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Schema\\\\Worker\\:\\:work\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			message: '#^Method Ibexa\\GraphQL\\Schema\\Worker\:\:work\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Schema/Worker.php
 
 		-
-			message: "#^Cannot cast object to string\\.$#"
+			message: '#^Cannot cast object to string\.$#'
+			identifier: cast.string
 			count: 1
 			path: src/lib/Value/ContentFieldValue.php
 
 		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Value\\\\ContentFieldValue\\:\\:\\$contentTypeId has no type specified\\.$#"
+			message: '#^Property Ibexa\\GraphQL\\Value\\ContentFieldValue\:\:\$contentTypeId has no type specified\.$#'
+			identifier: missingType.property
 			count: 1
 			path: src/lib/Value/ContentFieldValue.php
 
 		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Value\\\\ContentFieldValue\\:\\:\\$fieldDefIdentifier has no type specified\\.$#"
+			message: '#^Property Ibexa\\GraphQL\\Value\\ContentFieldValue\:\:\$fieldDefIdentifier has no type specified\.$#'
+			identifier: missingType.property
 			count: 1
 			path: src/lib/Value/ContentFieldValue.php
 
 		-
-			message: "#^Method Ibexa\\\\GraphQL\\\\Value\\\\Field\\:\\:fromField\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Value/Field.php
-
-		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Value\\\\Item\\:\\:\\$content \\(Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Content\\) does not accept Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Content\\|null\\.$#"
+			message: '#^Property Ibexa\\GraphQL\\Value\\Item\:\:\$content \(Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Content\) does not accept Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Content\|null\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: src/lib/Value/Item.php
 
 		-
-			message: "#^Property Ibexa\\\\GraphQL\\\\Value\\\\Item\\:\\:\\$location \\(Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location\\) does not accept Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Location\\|null\\.$#"
+			message: '#^Property Ibexa\\GraphQL\\Value\\Item\:\:\$location \(Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Location\) does not accept Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\Location\|null\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: src/lib/Value/Item.php

--- a/spec/InputMapper/SearchQueryMapperSpec.php
+++ b/spec/InputMapper/SearchQueryMapperSpec.php
@@ -1,145 +1,150 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
 namespace spec\Ibexa\GraphQL\InputMapper;
 
+use Ibexa\Contracts\Core\Repository\Values\Content\Query;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\Subtree;
 use Ibexa\GraphQL\InputMapper\ContentCollectionFilterBuilder;
 use Ibexa\GraphQL\InputMapper\SearchQueryMapper;
-use Ibexa\Contracts\Core\Repository\Values\Content\Query;
 use PhpSpec\ObjectBehavior;
 
 class SearchQueryMapperSpec extends ObjectBehavior
 {
-    function let(ContentCollectionFilterBuilder $filterBuilder)
+    public function let(ContentCollectionFilterBuilder $filterBuilder): void
     {
         $this->beConstructedWith($filterBuilder);
 
         $filterBuilder->buildFilter()->willReturn(new Subtree('/1/2/'));
     }
 
-    function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(SearchQueryMapper::class);
     }
 
-    public function it_maps_ContentTypeIdentifier_to_a_ContentTypeIdentifier_criterion()
+    public function it_maps_ContentTypeIdentifier_to_a_ContentTypeIdentifier_criterion(): void
     {
         $this->mapInputToQuery(['ContentTypeIdentifier' => ['article']])->shouldFilterByContentType(['article']);
     }
 
-    public function it_maps_Text_to_a_FullText_criterion()
+    public function it_maps_Text_to_a_FullText_criterion(): void
     {
         $this
             ->mapInputToQuery(['Text' => 'graphql'])
             ->shouldFilterByFullText('graphql');
     }
 
-    public function it_maps_Modified_before_to_a_created_lte_DateMetaData_criterion()
+    public function it_maps_Modified_before_to_a_created_lte_DateMetaData_criterion(): void
     {
         $this
             ->mapInputToQuery(['Modified' => ['before' => '1977/05/04']])
             ->shouldFilterByDateModified(Query\Criterion\Operator::LTE, '1977/05/04');
     }
 
-    public function it_maps_Modified_on_to_a_created_eq_DateMetaData_criterion()
+    public function it_maps_Modified_on_to_a_created_eq_DateMetaData_criterion(): void
     {
         $this
             ->mapInputToQuery(['Modified' => ['on' => '1977/05/04']])
             ->shouldFilterByDateModified(Query\Criterion\Operator::EQ, '1977/05/04');
     }
 
-    public function it_maps_Modified_after_to_a_created_gte_DateMetaData_criterion()
+    public function it_maps_Modified_after_to_a_created_gte_DateMetaData_criterion(): void
     {
         $this
             ->mapInputToQuery(['Modified' => ['after' => '1977/05/04']])
             ->shouldFilterByDateModified(Query\Criterion\Operator::GTE, '1977/05/04');
     }
 
-    public function it_maps_Created_before_to_a_created_lte_DateMetaData_criterion()
+    public function it_maps_Created_before_to_a_created_lte_DateMetaData_criterion(): void
     {
         $this
             ->mapInputToQuery(['Created' => ['before' => '1977/05/04']])
             ->shouldFilterByDateCreated(Query\Criterion\Operator::LTE, '1977/05/04');
     }
 
-    public function it_maps_Created_on_to_a_created_eq_DateMetaData_criterion()
+    public function it_maps_Created_on_to_a_created_eq_DateMetaData_criterion(): void
     {
         $this
             ->mapInputToQuery(['Created' => ['on' => '1977/05/04']])
             ->shouldFilterByDateCreated(Query\Criterion\Operator::EQ, '1977/05/04');
     }
 
-    public function it_maps_Created_after_to_a_created_gte_DateMetaData_criterion()
+    public function it_maps_Created_after_to_a_created_gte_DateMetaData_criterion(): void
     {
         $this
             ->mapInputToQuery(['Created' => ['after' => '1977/05/04']])
             ->shouldFilterByDateCreated(Query\Criterion\Operator::GTE, '1977/05/04');
     }
 
-    function it_maps_Field_to_a_Field_criterion()
+    public function it_maps_Field_to_a_Field_criterion(): void
     {
         $this
             ->mapInputToQuery(['Field' => ['target' => 'target_field', 'eq' => 'bar']])
             ->shouldFilterByField('target_field');
     }
 
-    function it_maps_Field_target_to_the_Field_criterion_target()
+    public function it_maps_Field_target_to_the_Field_criterion_target(): void
     {
         $this
             ->mapInputToQuery(['Field' => ['target' => 'target_field', 'eq' => 'bar']])
             ->shouldFilterByField('target_field', Query\Criterion\Operator::EQ, 'bar');
     }
 
-    function it_maps_Field_with_value_at_operator_key_to_the_Field_criterion_value()
+    public function it_maps_Field_with_value_at_operator_key_to_the_Field_criterion_value(): void
     {
         $this
             ->mapInputToQuery(['Field' => ['target' => 'target_field', 'eq' => 'bar']])
             ->shouldFilterByField('target_field', null, 'bar');
     }
 
-    function it_maps_Field_operator_eq_to_Field_criterion_operator_EQ()
+    public function it_maps_Field_operator_eq_to_Field_criterion_operator_EQ(): void
     {
         $this
             ->mapInputToQuery(['Field' => ['target' => 'target_field', 'eq' => 'bar']])
             ->shouldFilterByFieldWithOperator(Query\Criterion\Operator::EQ);
     }
 
-    function it_maps_Field_operator_in_to_Field_criterion_operator_IN()
+    public function it_maps_Field_operator_in_to_Field_criterion_operator_IN(): void
     {
         $this
             ->mapInputToQuery(['Field' => ['target' => 'target_field', 'eq' => 'bar']])
             ->shouldFilterByFieldWithOperator(Query\Criterion\Operator::EQ);
     }
 
-    function it_maps_Field_operator_lt_to_Field_criterion_operator_LT()
+    public function it_maps_Field_operator_lt_to_Field_criterion_operator_LT(): void
     {
         $this
             ->mapInputToQuery(['Field' => ['target' => 'target_field', 'lt' => 'bar']])
             ->shouldFilterByFieldWithOperator(Query\Criterion\Operator::LT);
     }
 
-    function it_maps_Field_operator_lte_to_Field_criterion_operator_LTE()
+    public function it_maps_Field_operator_lte_to_Field_criterion_operator_LTE(): void
     {
         $this
             ->mapInputToQuery(['Field' => ['target' => 'target_field', 'lte' => 'bar']])
             ->shouldFilterByFieldWithOperator(Query\Criterion\Operator::LTE);
     }
 
-    function it_maps_Field_operator_gte_to_Field_criterion_operator_GTE()
+    public function it_maps_Field_operator_gte_to_Field_criterion_operator_GTE(): void
     {
         $this
             ->mapInputToQuery(['Field' => ['target' => 'target_field', 'gte' => 'bar']])
             ->shouldFilterByFieldWithOperator(Query\Criterion\Operator::GTE);
     }
 
-    function it_maps_Field_operator_gt_to_Field_criterion_operator_GT()
+    public function it_maps_Field_operator_gt_to_Field_criterion_operator_GT(): void
     {
         $this
             ->mapInputToQuery(['Field' => ['target' => 'target_field', 'gt' => 'bar']])
             ->shouldFilterByFieldWithOperator(Query\Criterion\Operator::GT);
     }
 
-    function it_maps_Field_operator_between_to_Field_criterion_operator_BETWEEN()
+    public function it_maps_Field_operator_between_to_Field_criterion_operator_BETWEEN(): void
     {
         $this
             ->mapInputToQuery(['Field' => ['target' => 'target_field', 'between' => [10, 20]]])
@@ -149,7 +154,7 @@ class SearchQueryMapperSpec extends ObjectBehavior
     public function getMatchers(): array
     {
         return [
-            'filterByContentType' => function(Query $query, array $contentTypes) {
+            'filterByContentType' => function (Query $query, array $contentTypes): bool {
                 $criterion = $this->findCriterionInQueryFilter(
                     $query,
                     Query\Criterion\ContentTypeIdentifier::class
@@ -161,7 +166,7 @@ class SearchQueryMapperSpec extends ObjectBehavior
 
                 return $criterion->value === $contentTypes;
             },
-            'filterByFullText' => function(Query $query, $text) {
+            'filterByFullText' => function (Query $query, $text): bool {
                 $criterion = $this->findCriterionInQueryFilter(
                     $query,
                     Query\Criterion\FullText::class
@@ -173,7 +178,7 @@ class SearchQueryMapperSpec extends ObjectBehavior
 
                 return $criterion->value === $text;
             },
-            'filterByDateModified' => function(Query $query, $operator, $date) {
+            'filterByDateModified' => function (Query $query, $operator, $date): bool {
                 $criterion = $this->findCriterionInQueryFilter($query, Query\Criterion\DateMetadata::class);
 
                 if ($criterion === null) {
@@ -187,7 +192,7 @@ class SearchQueryMapperSpec extends ObjectBehavior
                 return $criterion->operator == $operator
                     && $criterion->value[0] == strtotime($date);
             },
-            'filterByDateCreated' => function(Query $query, $operator, $date) {
+            'filterByDateCreated' => function (Query $query, $operator, $date): bool {
                 $criterion = $this->findCriterionInQueryFilter($query, Query\Criterion\DateMetadata::class);
 
                 if ($criterion === null) {
@@ -201,7 +206,7 @@ class SearchQueryMapperSpec extends ObjectBehavior
                 return $criterion->operator == $operator
                     && $criterion->value[0] == strtotime($date);
             },
-            'filterByField' => function(Query $query, $field, $operator = null, $value = null) {
+            'filterByField' => function (Query $query, $field, $operator = null, $value = null): bool {
                 $criterion = $this->findCriterionInQueryFilter($query, Query\Criterion\Field::class);
 
                 if ($criterion === null) {
@@ -215,20 +220,21 @@ class SearchQueryMapperSpec extends ObjectBehavior
                 if ($operator !== null && $criterion->operator != $operator) {
                     return false;
                 }
-                return ($value === null || $criterion->value == $value);
+
+                return $value === null || $criterion->value == $value;
             },
-            'filterByFieldWithOperator' => function(Query $query, $operator) {
+            'filterByFieldWithOperator' => function (Query $query, $operator): bool {
                 $criterion = $this->findCriterionInQueryFilter($query, Query\Criterion\Field::class);
                 if ($criterion === null) {
                     return false;
                 }
 
                 return $criterion->operator == $operator;
-            }
+            },
         ];
     }
 
-    private function findCriterionInQueryFilter(Query $query, $searchedCriterionClass)
+    private function findCriterionInQueryFilter(Query $query, string $searchedCriterionClass)
     {
         if ($query->filter instanceof Query\Criterion\LogicalOperator) {
             return $this->findCriterionInCriterion($query->filter, $searchedCriterionClass);

--- a/spec/Resolver/DomainContentResolverSpec.php
+++ b/spec/Resolver/DomainContentResolverSpec.php
@@ -1,17 +1,22 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
 namespace spec\Ibexa\GraphQL\Resolver;
 
-use Ibexa\Core\Repository\Values\Content\Content;
+use Ibexa\Contracts\Core\Repository\Repository;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
-use Ibexa\Core\Repository\Values\Content\VersionInfo;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query;
+use Ibexa\Core\FieldType;
+use Ibexa\Core\Repository\Values\Content\Content;
+use Ibexa\Core\Repository\Values\Content\VersionInfo;
 use Ibexa\GraphQL\DataLoader\ContentLoader;
 use Ibexa\GraphQL\DataLoader\ContentTypeLoader;
 use Ibexa\GraphQL\InputMapper\QueryMapper;
 use Ibexa\GraphQL\Resolver\DomainContentResolver;
-use Ibexa\Contracts\Core\Repository\Repository;
-use Ibexa\Core\FieldType;
 use Ibexa\GraphQL\Value\Field;
 use Overblog\GraphQLBundle\Resolver\TypeResolver;
 use PhpSpec\ObjectBehavior;
@@ -19,24 +24,24 @@ use Prophecy\Argument;
 
 class DomainContentResolverSpec extends ObjectBehavior
 {
-    const CONTENT_ID = 1;
+    public const CONTENT_ID = 1;
 
-    function let(
+    public function let(
         Repository $repository,
         TypeResolver $typeResolver,
         QueryMapper $queryMapper,
         ContentLoader $contentLoader,
         ContentTypeLoader $contentTypeLoader
-    ) {
+    ): void {
         $this->beConstructedWith($repository, $typeResolver, $queryMapper, $contentLoader, $contentTypeLoader);
     }
 
-    function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(DomainContentResolver::class);
     }
 
-    function it_resolves_a_RelationList_field_value_with_multiple_to_an_array(ContentLoader $contentLoader)
+    public function it_resolves_a_RelationList_field_value_with_multiple_to_an_array(ContentLoader $contentLoader): void
     {
         $contentArray = $this->createContentList([self::CONTENT_ID]);
         $field = $this->createRelationListField($contentArray);
@@ -45,7 +50,7 @@ class DomainContentResolverSpec extends ObjectBehavior
         $this->resolveDomainRelationFieldValue($field, true)->shouldReturn($contentArray);
     }
 
-    function it_resolves_an_empty_RelationList_field_value_with_multiple_to_an_empty_array(ContentLoader $contentLoader)
+    public function it_resolves_an_empty_RelationList_field_value_with_multiple_to_an_empty_array(ContentLoader $contentLoader): void
     {
         $contentArray = [];
         $field = $this->createRelationListField($contentArray);
@@ -54,7 +59,7 @@ class DomainContentResolverSpec extends ObjectBehavior
         $this->resolveDomainRelationFieldValue($field, true)->shouldReturn([]);
     }
 
-    function it_resolves_a_Relation_field_value_without_multiple_to_a_content_item(ContentLoader $contentLoader)
+    public function it_resolves_a_Relation_field_value_without_multiple_to_a_content_item(ContentLoader $contentLoader): void
     {
         $content = $this->createContent(self::CONTENT_ID);
         $field = $this->createRelationField($content);
@@ -63,17 +68,17 @@ class DomainContentResolverSpec extends ObjectBehavior
         $this->resolveDomainRelationFieldValue($field, false)->shouldReturn($content);
     }
 
-    function it_resolves_an_empty_Relation_field_value_without_multiple_to_null(ContentLoader $contentLoader)
+    public function it_resolves_an_empty_Relation_field_value_without_multiple_to_null(ContentLoader $contentLoader): void
     {
         $field = $this->createEmptyRelationField();
 
         $contentLoader->find(Argument::any())->shouldNotBeCalled();
         $this->resolveDomainRelationFieldValue($field, false)->shouldReturn(null);
-
     }
 
     /**
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\Content[] $contentList
+     *
      * @return \Ibexa\GraphQL\Value\Field
      */
     private function createRelationListField(array $contentList): Field
@@ -91,7 +96,7 @@ class DomainContentResolverSpec extends ObjectBehavior
         return new Field(['value' => new FieldType\Relation\Value()]);
     }
 
-    private function createContentIdListQuery(array $contentList)
+    private function createContentIdListQuery(array $contentList): Query
     {
         return new Query(['filter' => new Query\Criterion\ContentId($this->extractContentIdList($contentList))]);
     }
@@ -103,12 +108,13 @@ class DomainContentResolverSpec extends ObjectBehavior
 
     /**
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\Content[] $contentList
+     *
      * @return array
      */
     private function extractContentIdList(array $contentList): array
     {
         return array_map(
-            function (Content $content) {
+            static function (Content $content) {
                 return $content->id;
             },
             $contentList
@@ -117,12 +123,13 @@ class DomainContentResolverSpec extends ObjectBehavior
 
     /**
      * @param int[] $contentIdList
+     *
      * @return \Ibexa\Core\Repository\Values\Content\Content[]
      */
     private function createContentList(array $contentIdList): array
     {
         return array_map(
-            function ($contentId) {
+            function ($contentId): Content {
                 return $this->createContent($contentId);
             },
             $contentIdList
@@ -131,14 +138,15 @@ class DomainContentResolverSpec extends ObjectBehavior
 
     /**
      * @param $contentId
+     *
      * @return \Ibexa\Core\Repository\Values\Content\Content
      */
-    private function createContent($contentId): Content
+    private function createContent(int $contentId): Content
     {
         return new Content([
             'versionInfo' => new VersionInfo([
-                'contentInfo' => new ContentInfo(['id' => $contentId])
-            ])
+                'contentInfo' => new ContentInfo(['id' => $contentId]),
+            ]),
         ]);
     }
 }

--- a/spec/Resolver/LocationGuesser/FilterLocationGuesserSpec.php
+++ b/spec/Resolver/LocationGuesser/FilterLocationGuesserSpec.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
 namespace spec\Ibexa\GraphQL\Resolver\LocationGuesser;
 
 use Ibexa\Core\Repository\Values\Content\Content;
@@ -8,32 +13,32 @@ use Ibexa\GraphQL\Resolver\LocationGuesser\FilterLocationGuesser;
 use Ibexa\GraphQL\Resolver\LocationGuesser\LocationFilter;
 use Ibexa\GraphQL\Resolver\LocationGuesser\LocationGuess;
 use Ibexa\GraphQL\Resolver\LocationGuesser\LocationGuesser;
-use Ibexa\GraphQL\Resolver\LocationGuesser\ObjectStorageLocationList;
 use Ibexa\GraphQL\Resolver\LocationGuesser\LocationList;
 use Ibexa\GraphQL\Resolver\LocationGuesser\LocationProvider;
+use Ibexa\GraphQL\Resolver\LocationGuesser\ObjectStorageLocationList;
 use PhpSpec\ObjectBehavior;
 
 class FilterLocationGuesserSpec extends ObjectBehavior
 {
-    function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(FilterLocationGuesser::class);
         $this->shouldHaveType(LocationGuesser::class);
     }
 
-    function let(LocationProvider $locationProvider, LocationFilter $locationFilter, LocationFilter $otherLocationFilter)
+    public function let(LocationProvider $locationProvider, LocationFilter $locationFilter, LocationFilter $otherLocationFilter): void
     {
         $this->beConstructedWith($locationProvider, [$locationFilter, $otherLocationFilter]);
     }
 
-    function it_gets_the_initial_location_list_from_the_provider(LocationProvider $locationProvider)
+    public function it_gets_the_initial_location_list_from_the_provider(LocationProvider $locationProvider): void
     {
         $content = new Content();
         $locationProvider->getLocations($content)->willReturn(new ObjectStorageLocationList($content));
         $this->guessLocation($content);
     }
 
-    function it_does_not_filter_if_there_is_only_one_location(LocationProvider $locationProvider, LocationFilter $locationFilter)
+    public function it_does_not_filter_if_there_is_only_one_location(LocationProvider $locationProvider, LocationFilter $locationFilter): void
     {
         $content = new Content();
         $location = new Location();
@@ -46,13 +51,12 @@ class FilterLocationGuesserSpec extends ObjectBehavior
         $this->guessLocation($content)->shouldBeLike(new LocationGuess($content, [$location]));
     }
 
-    function it_returns_as_soon_as_there_is_one_location_left(
+    public function it_returns_as_soon_as_there_is_one_location_left(
         LocationProvider $locationProvider,
         LocationFilter $locationFilter,
         LocationFilter $secondLocationFilter,
         LocationList $locationList
-    )
-    {
+    ): void {
         $content = new Content();
         $firstLocation = new Location();
         $secondLocation = new Location();
@@ -60,7 +64,7 @@ class FilterLocationGuesserSpec extends ObjectBehavior
         $locationProvider->getLocations($content)->willReturn($locationList);
         $locationList->hasOneLocation()->willReturn(false);
         $locationList->getLocations()->willReturn([$firstLocation]);
-        $locationFilter->filter($content, $locationList)->will(function ($args) use ($locationList) {
+        $locationFilter->filter($content, $locationList)->will(static function ($args) use ($locationList): void {
             $locationList->hasOneLocation()->willReturn(true);
         });
 
@@ -72,9 +76,9 @@ class FilterLocationGuesserSpec extends ObjectBehavior
     public function getMatchers(): array
     {
         return [
-            'guess' => function (LocationGuess $subject, Location $location) {
+            'guess' => static function (LocationGuess $subject, Location $location): bool {
                 return $subject->isSuccessful() && $subject->getLocation() === $location;
-            }
+            },
         ];
     }
 }

--- a/spec/Schema/Builder/SchemaBuilderSpec.php
+++ b/spec/Schema/Builder/SchemaBuilderSpec.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace spec\Ibexa\GraphQL\Schema\Builder;
 
 use Ibexa\GraphQL\Schema\Builder\Input;
@@ -23,17 +24,17 @@ class SchemaBuilderSpec extends ObjectBehavior
     public const ARG = 'arg';
     public const ARG_TYPE = 'Boolean';
 
-    public function let(NameValidator $nameValidator)
+    public function let(NameValidator $nameValidator): void
     {
         $this->beConstructedWith($nameValidator);
     }
 
-    public function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(SchemaBuilder::class);
     }
 
-    public function it_adds_a_type_to_the_schema(NameValidator $nameValidator)
+    public function it_adds_a_type_to_the_schema(NameValidator $nameValidator): void
     {
         $nameValidator->isValidName(Argument::any())->willReturn(true);
 
@@ -46,7 +47,7 @@ class SchemaBuilderSpec extends ObjectBehavior
         $schema->shouldHaveGraphQLTypeThatImplements('Interface');
     }
 
-    public function it_adds_a_field_to_an_existing_type(NameValidator $nameValidator)
+    public function it_adds_a_field_to_an_existing_type(NameValidator $nameValidator): void
     {
         $nameValidator->isValidName(Argument::any())->willReturn(true);
 
@@ -63,7 +64,7 @@ class SchemaBuilderSpec extends ObjectBehavior
         $schema->shouldHaveGraphQLTypeFieldWithResolve('@=query("myresolver")');
     }
 
-    public function it_adds_an_argument_to_an_existing_type_field(NameValidator $nameValidator)
+    public function it_adds_an_argument_to_an_existing_type_field(NameValidator $nameValidator): void
     {
         $nameValidator->isValidName(Argument::any())->willReturn(true);
 
@@ -81,42 +82,42 @@ class SchemaBuilderSpec extends ObjectBehavior
     public function getMatchers(): array
     {
         return [
-            'haveGraphQLType' => static function (array $schema) {
+            'haveGraphQLType' => static function (array $schema): bool {
                 return
                     isset($schema[self::TYPE]['type'])
                     && $schema[self::TYPE]['type'] === self::TYPE_TYPE;
             },
-            'haveGraphQLTypeThatInherits' => static function (array $schema, $inherits) {
+            'haveGraphQLTypeThatInherits' => static function (array $schema, $inherits): bool {
                 return
                     isset($schema[self::TYPE]['inherits'])
                     && in_array($inherits, $schema[self::TYPE]['inherits']);
             },
-            'haveGraphQLTypeThatImplements' => static function (array $schema, $interface) {
+            'haveGraphQLTypeThatImplements' => static function (array $schema, $interface): bool {
                 return
                     isset($schema[self::TYPE]['config']['interfaces'])
                     && in_array($interface, $schema[self::TYPE]['config']['interfaces']);
             },
-            'haveGraphQLTypeField' => static function (array $schema) {
+            'haveGraphQLTypeField' => static function (array $schema): bool {
                 return
                     isset($schema[self::TYPE]['config']['fields'][self::FIELD]['type'])
                     && $schema[self::TYPE]['config']['fields'][self::FIELD]['type'] === self::FIELD_TYPE;
             },
-            'haveGraphQLTypeFieldWithDescription' => static function (array $schema, $description) {
+            'haveGraphQLTypeFieldWithDescription' => static function (array $schema, $description): bool {
                 return
                     isset($schema[self::TYPE]['config']['fields'][self::FIELD]['description'])
                     && $schema[self::TYPE]['config']['fields'][self::FIELD]['description'] === $description;
             },
-            'haveGraphQLTypeFieldWithResolve' => static function (array $schema, $resolve) {
+            'haveGraphQLTypeFieldWithResolve' => static function (array $schema, $resolve): bool {
                 return
                     isset($schema[self::TYPE]['config']['fields'][self::FIELD]['description'])
                     && $schema[self::TYPE]['config']['fields'][self::FIELD]['resolve'] === $resolve;
             },
-            'haveGraphQLTypeFieldArg' => static function (array $schema) {
+            'haveGraphQLTypeFieldArg' => static function (array $schema): bool {
                 return
                     isset($schema[self::TYPE]['config']['fields'][self::FIELD]['args'][self::ARG]['type'])
                     && $schema[self::TYPE]['config']['fields'][self::FIELD]['args'][self::ARG]['type'] === self::ARG_TYPE;
             },
-            'haveGraphQLTypeFieldArgWithDescription' => static function (array $schema, $description) {
+            'haveGraphQLTypeFieldArgWithDescription' => static function (array $schema, $description): bool {
                 return
                     isset($schema[self::TYPE]['config']['fields'][self::FIELD]['args'][self::ARG]['description'])
                     && $schema[self::TYPE]['config']['fields'][self::FIELD]['args'][self::ARG]['description'] === $description;

--- a/spec/Schema/Domain/Content/ContentDomainIteratorSpec.php
+++ b/spec/Schema/Domain/Content/ContentDomainIteratorSpec.php
@@ -4,6 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace spec\Ibexa\GraphQL\Schema\Domain\Content;
 
 use Ibexa\Contracts\Core\Repository\ContentTypeService;
@@ -14,25 +15,25 @@ use Ibexa\Core\Repository\Values\ContentType\FieldDefinitionCollection;
 use Ibexa\GraphQL\Schema\Builder;
 use Ibexa\GraphQL\Schema\Domain;
 use Ibexa\GraphQL\Schema\Domain\NameValidator;
-use spec\Ibexa\GraphQL\Tools\TypeArgument;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use spec\Ibexa\GraphQL\Tools\TypeArgument;
 
 class ContentDomainIteratorSpec extends ObjectBehavior
 {
     public function let(
         ContentTypeService $contentTypeService,
         NameValidator $nameValidator
-    ) {
+    ): void {
         $this->beConstructedWith($contentTypeService, $nameValidator);
     }
 
-    public function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(Domain\Iterator::class);
     }
 
-    public function it_initializes_the_schema_with_the_Platform_root_type(Builder $schema)
+    public function it_initializes_the_schema_with_the_Platform_root_type(Builder $schema): void
     {
         $this->init($schema);
 
@@ -47,7 +48,7 @@ class ContentDomainIteratorSpec extends ObjectBehavior
     public function it_yields_content_type_groups(
         ContentTypeService $contentTypeService,
         NameValidator $nameValidator
-    ) {
+    ): void {
         $nameValidator->isValidName(Argument::any())->willReturn(true);
 
         $contentTypeService->loadContentTypeGroups()->willReturn([
@@ -69,7 +70,7 @@ class ContentDomainIteratorSpec extends ObjectBehavior
     public function it_yields_content_types_with_their_group_from_a_content_type_group(
         ContentTypeService $contentTypeService,
         NameValidator $nameValidator
-    ) {
+    ): void {
         $nameValidator->isValidName(Argument::any())->willReturn(true);
 
         $contentTypeService->loadContentTypeGroups()->willReturn([
@@ -94,7 +95,7 @@ class ContentDomainIteratorSpec extends ObjectBehavior
     public function it_yields_fields_definitions_with_their_content_types_and_group_from_a_content_type(
         ContentTypeService $contentTypeService,
         NameValidator $nameValidator
-    ) {
+    ): void {
         $nameValidator->isValidName(Argument::any())->willReturn(true);
 
         $contentTypeService->loadContentTypeGroups()->willReturn([
@@ -125,7 +126,7 @@ class ContentDomainIteratorSpec extends ObjectBehavior
     public function it_only_yields_fields_definitions_from_the_current_content_type(
         ContentTypeService $contentTypeService,
         NameValidator $nameValidator
-    ) {
+    ): void {
         $nameValidator->isValidName(Argument::any())->willReturn(true);
 
         $contentTypeService->loadContentTypeGroups()->willReturn([

--- a/spec/Schema/Domain/Content/Mapper/FieldDefinition/ConfigurableFieldDefinitionMapperSpec.php
+++ b/spec/Schema/Domain/Content/Mapper/FieldDefinition/ConfigurableFieldDefinitionMapperSpec.php
@@ -1,39 +1,44 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
 namespace spec\Ibexa\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition;
 
-use Ibexa\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition\ConfigurableFieldDefinitionMapper;
-use Ibexa\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\Contracts\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionMapper;
+use Ibexa\Core\Repository\Values\ContentType\FieldDefinition;
+use Ibexa\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition\ConfigurableFieldDefinitionMapper;
 use PhpSpec\ObjectBehavior;
 
 class ConfigurableFieldDefinitionMapperSpec extends ObjectBehavior
 {
-    const FIELD_IDENTIFIER = 'test';
-    const CONFIG = [
+    public const FIELD_IDENTIFIER = 'test';
+    public const CONFIG = [
         'configured_type' => [
             'value_type' => self::VALUE_TYPE,
             'definition_type' => self::DEFINITION_TYPE,
             'value_resolver' => self::VALUE_RESOLVER,
-        ]
+        ],
     ];
 
-    const VALUE_TYPE = 'ConfiguredFieldValue';
-    const VALUE_RESOLVER = 'valueResolver';
-    const DEFINITION_TYPE = 'ConfiguredFieldDefinition';
+    public const VALUE_TYPE = 'ConfiguredFieldValue';
+    public const VALUE_RESOLVER = 'valueResolver';
+    public const DEFINITION_TYPE = 'ConfiguredFieldDefinition';
 
-    function let(FieldDefinitionMapper $innerMapper)
+    public function let(FieldDefinitionMapper $innerMapper): void
     {
         $this->beConstructedWith($innerMapper, self::CONFIG);
     }
 
-    function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(ConfigurableFieldDefinitionMapper::class);
         $this->shouldHaveType(FieldDefinitionMapper::class);
     }
 
-    function it_calls_the_inner_mapper_if_it_does_not_have_a_value_type_for_a_field_type_identifier(FieldDefinitionMapper $innerMapper)
+    public function it_calls_the_inner_mapper_if_it_does_not_have_a_value_type_for_a_field_type_identifier(FieldDefinitionMapper $innerMapper): void
     {
         $fieldDefinition = $this->createUnconfiguredFieldDefinition();
 
@@ -41,7 +46,7 @@ class ConfigurableFieldDefinitionMapperSpec extends ObjectBehavior
         $innerMapper->mapToFieldValueType($fieldDefinition)->shouldHaveBeenCalled();
     }
 
-    function it_returns_the_value_type_for_a_configured_field_type_identifier(FieldDefinitionMapper $innerMapper)
+    public function it_returns_the_value_type_for_a_configured_field_type_identifier(FieldDefinitionMapper $innerMapper): void
     {
         $fieldDefinition = $this->createConfiguredFieldDefinition();
 
@@ -49,7 +54,7 @@ class ConfigurableFieldDefinitionMapperSpec extends ObjectBehavior
         $innerMapper->mapToFieldValueType($fieldDefinition)->shouldNotHaveBeenCalled();
     }
 
-    function it_calls_the_inner_mapper_if_it_does_not_have_a_definition_type_for_a_field_type_identifier(FieldDefinitionMapper $innerMapper)
+    public function it_calls_the_inner_mapper_if_it_does_not_have_a_definition_type_for_a_field_type_identifier(FieldDefinitionMapper $innerMapper): void
     {
         $fieldDefinition = $this->createUnconfiguredFieldDefinition();
 
@@ -57,7 +62,7 @@ class ConfigurableFieldDefinitionMapperSpec extends ObjectBehavior
         $innerMapper->mapToFieldDefinitionType($fieldDefinition)->shouldHaveBeenCalled();
     }
 
-    function it_returns_the_definition_type_for_a_configured_field_type_identifier(FieldDefinitionMapper $innerMapper)
+    public function it_returns_the_definition_type_for_a_configured_field_type_identifier(FieldDefinitionMapper $innerMapper): void
     {
         $fieldDefinition = $this->createConfiguredFieldDefinition();
 
@@ -65,7 +70,7 @@ class ConfigurableFieldDefinitionMapperSpec extends ObjectBehavior
         $innerMapper->mapToFieldDefinitionType($fieldDefinition)->shouldNotHaveBeenCalled();
     }
 
-    function it_calls_the_inner_mapper_if_it_does_not_have_a_value_resolver_for_a_field_type_identifier(FieldDefinitionMapper $innerMapper)
+    public function it_calls_the_inner_mapper_if_it_does_not_have_a_value_resolver_for_a_field_type_identifier(FieldDefinitionMapper $innerMapper): void
     {
         $fieldDefinition = $this->createUnconfiguredFieldDefinition();
 
@@ -73,7 +78,7 @@ class ConfigurableFieldDefinitionMapperSpec extends ObjectBehavior
         $innerMapper->mapToFieldDefinitionType($fieldDefinition)->shouldHaveBeenCalled();
     }
 
-    function it_returns_the_completed_value_resolver_for_a_configured_field_type_identifier(FieldDefinitionMapper $innerMapper)
+    public function it_returns_the_completed_value_resolver_for_a_configured_field_type_identifier(FieldDefinitionMapper $innerMapper): void
     {
         $fieldDefinition = $this->createConfiguredFieldDefinition();
 

--- a/spec/Schema/Domain/Content/Mapper/FieldDefinition/RelationFieldDefinitionMapperSpec.php
+++ b/spec/Schema/Domain/Content/Mapper/FieldDefinition/RelationFieldDefinitionMapperSpec.php
@@ -1,22 +1,27 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
 namespace spec\Ibexa\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition;
 
-use Ibexa\Contracts\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionMapper;
-use Ibexa\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition\RelationFieldDefinitionMapper;
-use Ibexa\GraphQL\Schema\Domain\Content\NameHelper;
 use Ibexa\Contracts\Core\Repository\ContentTypeService;
+use Ibexa\Contracts\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionMapper;
 use Ibexa\Core\Repository\Values\ContentType\ContentType;
 use Ibexa\Core\Repository\Values\ContentType\FieldDefinition;
+use Ibexa\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition\RelationFieldDefinitionMapper;
+use Ibexa\GraphQL\Schema\Domain\Content\NameHelper;
 use PhpSpec\ObjectBehavior;
 
 class RelationFieldDefinitionMapperSpec extends ObjectBehavior
 {
-    const DEF_LIMIT_SINGLE = 1;
-    const DEF_LIMIT_MULTI = 5;
-    const DEF_LIMIT_NONE = 0;
+    public const DEF_LIMIT_SINGLE = 1;
+    public const DEF_LIMIT_MULTI = 5;
+    public const DEF_LIMIT_NONE = 0;
 
-    function let(NameHelper $nameHelper, ContentTypeService $contentTypeService, FieldDefinitionMapper $innerMapper)
+    public function let(NameHelper $nameHelper, ContentTypeService $contentTypeService, FieldDefinitionMapper $innerMapper): void
     {
         $this->beConstructedWith($innerMapper, $nameHelper, $contentTypeService);
 
@@ -29,68 +34,68 @@ class RelationFieldDefinitionMapperSpec extends ObjectBehavior
         $nameHelper->itemName($folderContentType)->willReturn('FolderItem');
     }
 
-    function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(RelationFieldDefinitionMapper::class);
         $this->shouldHaveType(FieldDefinitionMapper::class);
     }
 
-    function it_maps_single_selection_without_type_limitations_to_a_single_generic_content()
+    public function it_maps_single_selection_without_type_limitations_to_a_single_generic_content(): void
     {
         $fieldDefinition = $this->createFieldDefinition(self::DEF_LIMIT_SINGLE, []);
         $this->mapToFieldValueType($fieldDefinition)->shouldReturn('Item');
     }
 
-    function it_maps_single_selection_with_multiple_type_limitations_to_a_single_generic_content()
+    public function it_maps_single_selection_with_multiple_type_limitations_to_a_single_generic_content(): void
     {
         $fieldDefinition = $this->createFieldDefinition(self::DEF_LIMIT_SINGLE, ['article', 'blog_post']);
         $this->mapToFieldValueType($fieldDefinition)->shouldReturn('Item');
     }
 
-    function it_maps_single_selection_with_a_unique_type_limitations_to_a_single_item_of_that_type()
+    public function it_maps_single_selection_with_a_unique_type_limitations_to_a_single_item_of_that_type(): void
     {
         $fieldDefinition = $this->createFieldDefinition(self::DEF_LIMIT_SINGLE, ['article']);
         $this->mapToFieldValueType($fieldDefinition)->shouldReturn('ArticleItem');
     }
 
-    function it_maps_multi_selection_without_type_limitations_to_an_array_of_generic_content()
+    public function it_maps_multi_selection_without_type_limitations_to_an_array_of_generic_content(): void
     {
         $fieldDefinition = $this->createFieldDefinition(self::DEF_LIMIT_MULTI, []);
         $this->mapToFieldValueType($fieldDefinition)->shouldReturn('[Item]');
     }
 
-    function it_maps_multi_selection_with_multiple_type_limitations_to_an_array_of_generic_content()
+    public function it_maps_multi_selection_with_multiple_type_limitations_to_an_array_of_generic_content(): void
     {
         $fieldDefinition = $this->createFieldDefinition(self::DEF_LIMIT_NONE, ['article', 'blog_post']);
         $this->mapToFieldValueType($fieldDefinition)->shouldReturn('[Item]');
     }
 
-    function it_maps_multi_selection_with_a_unique_type_limitations_to_an_array_of_that_type()
+    public function it_maps_multi_selection_with_a_unique_type_limitations_to_an_array_of_that_type(): void
     {
         $fieldDefinition = $this->createFieldDefinition(self::DEF_LIMIT_MULTI, ['article']);
         $this->mapToFieldValueType($fieldDefinition)->shouldReturn('[ArticleItem]');
     }
 
-    function it_delegates_the_field_definition_type_to_the_inner_mapper(FieldDefinitionMapper $innerMapper)
+    public function it_delegates_the_field_definition_type_to_the_inner_mapper(FieldDefinitionMapper $innerMapper): void
     {
         $fieldDefinition = $this->createFieldDefinition();
         $innerMapper->mapToFieldDefinitionType($fieldDefinition)->willReturn('SomeFieldDefinition');
         $this->mapToFieldDefinitionType($fieldDefinition)->shouldReturn('SomeFieldDefinition');
     }
 
-    function it_maps_multi_selection_to_resolve_multiple()
+    public function it_maps_multi_selection_to_resolve_multiple(): void
     {
         $fieldDefinition = $this->createFieldDefinition(self::DEF_LIMIT_MULTI);
         $this->mapToFieldValueResolver($fieldDefinition)->shouldReturn('@=query("RelationFieldValue", field, true)');
     }
 
-    function it_maps_single_selection_to_resolve_single()
+    public function it_maps_single_selection_to_resolve_single(): void
     {
         $fieldDefinition = $this->createFieldDefinition(self::DEF_LIMIT_SINGLE);
         $this->mapToFieldValueResolver($fieldDefinition)->shouldReturn('@=query("RelationFieldValue", field, false)');
     }
 
-    private function createFieldDefinition($selectionLimit = 0, $selectionContentTypes = [])
+    private function createFieldDefinition(int $selectionLimit = 0, array $selectionContentTypes = []): FieldDefinition
     {
         return new FieldDefinition([
             'fieldTypeIdentifier' => 'ezobjectrelationlist',
@@ -98,7 +103,7 @@ class RelationFieldDefinitionMapperSpec extends ObjectBehavior
                 'selectionContentTypes' => $selectionContentTypes,
             ],
             'validatorConfiguration' => [
-                'RelationListValueValidator' => ['selectionLimit' => $selectionLimit]
+                'RelationListValueValidator' => ['selectionLimit' => $selectionLimit],
             ],
         ]);
     }

--- a/spec/Schema/Domain/Content/Mapper/FieldDefinition/SelectionFieldDefinitionMapperSpec.php
+++ b/spec/Schema/Domain/Content/Mapper/FieldDefinition/SelectionFieldDefinitionMapperSpec.php
@@ -1,35 +1,39 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
 namespace spec\Ibexa\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition;
 
-use Ibexa\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\Contracts\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionMapper;
+use Ibexa\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition\SelectionFieldDefinitionMapper;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class SelectionFieldDefinitionMapperSpec extends ObjectBehavior
 {
-    const FIELD_IDENTIFIER = 'test';
-    const TYPE_IDENTIFIER = 'ezselection';
+    public const FIELD_IDENTIFIER = 'test';
+    public const TYPE_IDENTIFIER = 'ezselection';
 
-    function let(FieldDefinitionMapper $innerMapper)
+    public function let(FieldDefinitionMapper $innerMapper): void
     {
         $this->beConstructedWith($innerMapper);
     }
 
-    function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(SelectionFieldDefinitionMapper::class);
         $this->shouldHaveType(FieldDefinitionMapper::class);
     }
 
-    function it_maps_to_an_array_of_strings_if_multiple_is_set_to_true()
+    public function it_maps_to_an_array_of_strings_if_multiple_is_set_to_true(): void
     {
         $this->mapToFieldValueType($this->createMultiFieldDefinition())->shouldReturn('[String]');
     }
 
-    function it_maps_to_a_string_if_multiple_is_set_to_false()
+    public function it_maps_to_a_string_if_multiple_is_set_to_false(): void
     {
         $this->mapToFieldValueType($this->createSingleFieldDefinition())->shouldReturn('String');
     }
@@ -44,14 +48,14 @@ class SelectionFieldDefinitionMapperSpec extends ObjectBehavior
         return $this->createFieldDefinition(['isMultiple' => true]);
     }
 
-    private function createFieldDefinition($options)
+    private function createFieldDefinition(array $options): FieldDefinition
     {
         return new FieldDefinition([
             'identifier' => self::FIELD_IDENTIFIER,
             'fieldTypeIdentifier' => self::TYPE_IDENTIFIER,
             'fieldSettings' => [
-                'isMultiple' => $options['isMultiple'] ?? false
-            ]
+                'isMultiple' => $options['isMultiple'] ?? false,
+            ],
         ]);
     }
 }

--- a/spec/Schema/Domain/Content/Worker/ContentType/AddItemOfTypeConnectionToGroupSpec.php
+++ b/spec/Schema/Domain/Content/Worker/ContentType/AddItemOfTypeConnectionToGroupSpec.php
@@ -1,23 +1,28 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
 namespace spec\Ibexa\GraphQL\Schema\Domain\Content\Worker\ContentType;
 
 use Ibexa\GraphQL\Schema\Builder\SchemaBuilder;
 use Ibexa\GraphQL\Schema\Domain\Content\NameHelper;
 use Ibexa\GraphQL\Schema\Domain\Content\Worker\ContentType\AddItemOfTypeConnectionToGroup;
+use Prophecy\Argument;
 use spec\Ibexa\GraphQL\Tools\ContentTypeArgument;
 use spec\Ibexa\GraphQL\Tools\ContentTypeGroupArgument;
 use spec\Ibexa\GraphQL\Tools\FieldArgArgument;
 use spec\Ibexa\GraphQL\Tools\FieldArgument;
-use Prophecy\Argument;
 
 class AddItemOfTypeConnectionToGroupSpec extends ContentTypeWorkerBehavior
 {
-    const GROUP_TYPE = 'ItemTestGroup';
-    const TYPE_TYPE = 'TestItemConnection';
-    const CONNECTION_FIELD = 'testTypes';
+    public const GROUP_TYPE = 'ItemTestGroup';
+    public const TYPE_TYPE = 'TestItemConnection';
+    public const CONNECTION_FIELD = 'testTypes';
 
-    function let(NameHelper $nameHelper)
+    public function let(NameHelper $nameHelper): void
     {
         $this->setNameHelper($nameHelper);
 
@@ -34,30 +39,30 @@ class AddItemOfTypeConnectionToGroupSpec extends ContentTypeWorkerBehavior
             ->willReturn(self::TYPE_TYPE);
     }
 
-    function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(AddItemOfTypeConnectionToGroup::class);
     }
 
-    function it_can_not_work_if_args_do_not_include_a_ContentTypeGroup(SchemaBuilder $schema)
+    public function it_can_not_work_if_args_do_not_include_a_ContentTypeGroup(SchemaBuilder $schema): void
     {
         $this->canWork($schema, [])->shouldBe(false);
     }
 
-    function it_can_not_work_if_args_do_not_include_a_ContentType(SchemaBuilder $schema)
+    public function it_can_not_work_if_args_do_not_include_a_ContentType(SchemaBuilder $schema): void
     {
         $args = $this->args();
         unset($args['ContentType']);
         $this->canWork($schema, $args)->shouldBe(false);
     }
 
-    function it_can_not_work_if_the_collection_field_is_already_set(SchemaBuilder $schema)
+    public function it_can_not_work_if_the_collection_field_is_already_set(SchemaBuilder $schema): void
     {
         $schema->hasTypeWithField(self::GROUP_TYPE, self::CONNECTION_FIELD)->willReturn(true);
         $this->canWork($schema, $this->args())->shouldBe(false);
     }
 
-    function it_adds_a_collection_field_for_the_ContentType_to_the_ContentTypeGroup(SchemaBuilder $schema)
+    public function it_adds_a_collection_field_for_the_ContentType_to_the_ContentTypeGroup(SchemaBuilder $schema): void
     {
         $schema
             ->addFieldToType(

--- a/spec/Schema/Domain/Content/Worker/ContentType/AddItemToGroupSpec.php
+++ b/spec/Schema/Domain/Content/Worker/ContentType/AddItemToGroupSpec.php
@@ -1,12 +1,17 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
 namespace spec\Ibexa\GraphQL\Schema\Domain\Content\Worker\ContentType;
 
 use Ibexa\GraphQL\Schema\Domain\Content\Worker\ContentType\AddItemToGroup;
 
 class AddItemToGroupSpec extends ContentTypeWorkerBehavior
 {
-    function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(AddItemToGroup::class);
     }

--- a/spec/Schema/Domain/Content/Worker/ContentType/AddItemTypeToItemGroupTypesSpec.php
+++ b/spec/Schema/Domain/Content/Worker/ContentType/AddItemTypeToItemGroupTypesSpec.php
@@ -1,23 +1,28 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
 namespace spec\Ibexa\GraphQL\Schema\Domain\Content\Worker\ContentType;
 
 use Ibexa\GraphQL\Schema\Builder\SchemaBuilder;
 use Ibexa\GraphQL\Schema\Domain\Content\NameHelper;
 use Ibexa\GraphQL\Schema\Domain\Content\Worker\ContentType\AddItemTypeToItemGroupTypes;
+use Prophecy\Argument;
 use spec\Ibexa\GraphQL\Tools\ContentTypeArgument;
 use spec\Ibexa\GraphQL\Tools\ContentTypeGroupArgument;
 use spec\Ibexa\GraphQL\Tools\FieldArgument;
-use Prophecy\Argument;
 
 class AddItemTypeToItemGroupTypesSpec extends ContentTypeWorkerBehavior
 {
-    const GROUP_TYPES_TYPE = 'DomainGroupTestGroupTypes';
+    public const GROUP_TYPES_TYPE = 'DomainGroupTestGroupTypes';
 
-    const TYPE_FIELD = 'testType';
-    const TYPE_TYPE = 'TestTypeType';
+    public const TYPE_FIELD = 'testType';
+    public const TYPE_TYPE = 'TestTypeType';
 
-    public function let(NameHelper $nameHelper)
+    public function let(NameHelper $nameHelper): void
     {
         $this->setNameHelper($nameHelper);
 
@@ -40,30 +45,30 @@ class AddItemTypeToItemGroupTypesSpec extends ContentTypeWorkerBehavior
             ->willReturn(self::GROUP_TYPES_TYPE);
     }
 
-    function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(AddItemTypeToItemGroupTypes::class);
     }
 
-    function it_can_not_work_if_args_do_not_have_a_ContentTypeGroup(SchemaBuilder $schema)
+    public function it_can_not_work_if_args_do_not_have_a_ContentTypeGroup(SchemaBuilder $schema): void
     {
         $this->canWork($schema, [])->shouldBe(false);
     }
 
-    function it_can_not_work_if_args_do_not_have_a_ContentType(SchemaBuilder $schema)
+    public function it_can_not_work_if_args_do_not_have_a_ContentType(SchemaBuilder $schema): void
     {
         $args = $this->args();
         unset($args['ContentType']);
         $this->canWork($schema, $args)->shouldBe(false);
     }
 
-    function it_can_not_work_if_the_field_is_already_defined(SchemaBuilder $schema)
+    public function it_can_not_work_if_the_field_is_already_defined(SchemaBuilder $schema): void
     {
         $schema->hasTypeWithField(self::GROUP_TYPES_TYPE, self::TYPE_FIELD)->willReturn(true);
         $this->canWork($schema, $this->args())->shouldBe(false);
     }
 
-    function it_adds_a_field_for_the_ContentType_to_the_DomainGroupTypes_object(SchemaBuilder $schema)
+    public function it_adds_a_field_for_the_ContentType_to_the_DomainGroupTypes_object(SchemaBuilder $schema): void
     {
         $schema
             ->addFieldToType(

--- a/spec/Schema/Domain/Content/Worker/ContentType/AddItemTypeToItemTypeIdentifierListSpec.php
+++ b/spec/Schema/Domain/Content/Worker/ContentType/AddItemTypeToItemTypeIdentifierListSpec.php
@@ -1,41 +1,46 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
 namespace spec\Ibexa\GraphQL\Schema\Domain\Content\Worker\ContentType;
 
 use Ibexa\GraphQL\Schema\Builder\SchemaBuilder;
 use Ibexa\GraphQL\Schema\Domain\Content\NameHelper;
 use Ibexa\GraphQL\Schema\Domain\Content\Worker\ContentType\AddItemTypeToItemTypeIdentifierList;
-use spec\Ibexa\GraphQL\Tools\EnumValueArgument;
 use Prophecy\Argument;
+use spec\Ibexa\GraphQL\Tools\EnumValueArgument;
 
 class AddItemTypeToItemTypeIdentifierListSpec extends ContentTypeWorkerBehavior
 {
-    const ENUM_TYPE = 'ContentTypeIdentifier';
+    public const ENUM_TYPE = 'ContentTypeIdentifier';
 
-    public function let(NameHelper $nameHelper)
+    public function let(NameHelper $nameHelper): void
     {
         $this->setNameHelper($nameHelper);
     }
 
-    function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(AddItemTypeToItemTypeIdentifierList::class);
     }
 
-    function it_can_not_work_if_args_do_not_have_a_ContentType(SchemaBuilder $schema)
+    public function it_can_not_work_if_args_do_not_have_a_ContentType(SchemaBuilder $schema): void
     {
         $args = $this->args();
         unset($args['ContentType']);
         $this->canWork($schema, [])->shouldBe(false);
     }
 
-    function it_can_not_work_if_the_ContentTypeIdentifier_enum_is_not_defined(SchemaBuilder $schema)
+    public function it_can_not_work_if_the_ContentTypeIdentifier_enum_is_not_defined(SchemaBuilder $schema): void
     {
         $schema->hasType(self::ENUM_TYPE)->willReturn(false);
         $this->canWork($schema, $this->args())->shouldBe(false);
     }
 
-    function it_adds_a_field_for_the_ContentType_to_the_ContentTypeIdentifier_enum(SchemaBuilder $schema)
+    public function it_adds_a_field_for_the_ContentType_to_the_ContentTypeIdentifier_enum(SchemaBuilder $schema): void
     {
         $schema
             ->addValueToEnum(

--- a/spec/Schema/Domain/Content/Worker/ContentType/DefineItemSpec.php
+++ b/spec/Schema/Domain/Content/Worker/ContentType/DefineItemSpec.php
@@ -1,19 +1,24 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
 namespace spec\Ibexa\GraphQL\Schema\Domain\Content\Worker\ContentType;
 
 use Ibexa\GraphQL\Schema\Builder\SchemaBuilder;
 use Ibexa\GraphQL\Schema\Domain\Content\NameHelper;
 use Ibexa\GraphQL\Schema\Domain\Content\Worker\ContentType\DefineItem;
+use Prophecy\Argument;
 use spec\Ibexa\GraphQL\Tools\ContentTypeArgument;
 use spec\Ibexa\GraphQL\Tools\TypeArgument;
-use Prophecy\Argument;
 
 class DefineItemSpec extends ContentTypeWorkerBehavior
 {
-    const TYPE_TYPE = 'TestTypeItem';
+    public const TYPE_TYPE = 'TestTypeItem';
 
-    function let(NameHelper $nameHelper)
+    public function let(NameHelper $nameHelper): void
     {
         $nameHelper
             ->itemName(ContentTypeArgument::withIdentifier(self::TYPE_IDENTIFIER))
@@ -22,24 +27,24 @@ class DefineItemSpec extends ContentTypeWorkerBehavior
         $this->setNameHelper($nameHelper);
     }
 
-    function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(DefineItem::class);
     }
 
-    function it_can_not_work_if_args_do_not_include_a_ContentTypeGroup(SchemaBuilder $schema)
+    public function it_can_not_work_if_args_do_not_include_a_ContentTypeGroup(SchemaBuilder $schema): void
     {
         $this->canWork($schema, [])->shouldBe(false);
     }
 
-    function it_can_not_work_if_args_do_not_include_a_ContentType(SchemaBuilder $schema)
+    public function it_can_not_work_if_args_do_not_include_a_ContentType(SchemaBuilder $schema): void
     {
         $args = $this->args();
         unset($args['ContentType']);
         $this->canWork($schema, $args)->shouldBe(false);
     }
 
-    function it_defines_a_DomainContent_type_based_on_the_ContentType(SchemaBuilder $schema)
+    public function it_defines_a_DomainContent_type_based_on_the_ContentType(SchemaBuilder $schema): void
     {
         $schema
             ->addType(Argument::allOf(
@@ -49,7 +54,7 @@ class DefineItemSpec extends ContentTypeWorkerBehavior
                 TypeArgument::implements('Item')
             ))
             ->shouldBeCalled();
-        
+
         $this->work($schema, $this->args());
     }
 }

--- a/spec/Schema/Domain/Content/Worker/ContentType/DefineItemTypeSpec.php
+++ b/spec/Schema/Domain/Content/Worker/ContentType/DefineItemTypeSpec.php
@@ -1,19 +1,24 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
 namespace spec\Ibexa\GraphQL\Schema\Domain\Content\Worker\ContentType;
 
 use Ibexa\GraphQL\Schema\Builder\SchemaBuilder;
 use Ibexa\GraphQL\Schema\Domain\Content\NameHelper;
 use Ibexa\GraphQL\Schema\Domain\Content\Worker\ContentType\DefineItemType;
+use Prophecy\Argument;
 use spec\Ibexa\GraphQL\Tools\ContentTypeArgument;
 use spec\Ibexa\GraphQL\Tools\TypeArgument;
-use Prophecy\Argument;
 
 class DefineItemTypeSpec extends ContentTypeWorkerBehavior
 {
-    const TYPE_TYPE = 'TestTypeType';
+    public const TYPE_TYPE = 'TestTypeType';
 
-    function let(NameHelper $nameHelper)
+    public function let(NameHelper $nameHelper): void
     {
         $nameHelper
             ->itemTypeName(ContentTypeArgument::withIdentifier(self::TYPE_IDENTIFIER))
@@ -22,24 +27,24 @@ class DefineItemTypeSpec extends ContentTypeWorkerBehavior
         $this->setNameHelper($nameHelper);
     }
 
-    function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(DefineItemType::class);
     }
 
-    function it_can_not_work_if_args_do_not_include_a_ContentTypeGroup(SchemaBuilder $schema)
+    public function it_can_not_work_if_args_do_not_include_a_ContentTypeGroup(SchemaBuilder $schema): void
     {
         $this->canWork($schema, [])->shouldBe(false);
     }
 
-    function it_can_not_work_if_args_do_not_include_a_ContentType(SchemaBuilder $schema)
+    public function it_can_not_work_if_args_do_not_include_a_ContentType(SchemaBuilder $schema): void
     {
         $args = $this->args();
         unset($args['ContentType']);
         $this->canWork($schema, $args)->shouldBe(false);
     }
 
-    function it_defines_a_DomainContent_type_based_on_the_ContentType(SchemaBuilder $schema)
+    public function it_defines_a_DomainContent_type_based_on_the_ContentType(SchemaBuilder $schema): void
     {
         $schema
             ->addType(Argument::allOf(

--- a/spec/Schema/Domain/Content/Worker/ContentTypeGroup/AddDomainGroupToDomainSpec.php
+++ b/spec/Schema/Domain/Content/Worker/ContentTypeGroup/AddDomainGroupToDomainSpec.php
@@ -1,22 +1,27 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
 namespace spec\Ibexa\GraphQL\Schema\Domain\Content\Worker\ContentTypeGroup;
 
 use Ibexa\Contracts\Core\Repository\ContentTypeService;
+use Ibexa\Core\Repository\Values\ContentType\ContentTypeGroup;
 use Ibexa\GraphQL\Schema\Builder\SchemaBuilder;
 use Ibexa\GraphQL\Schema\Domain\Content\NameHelper;
 use Ibexa\GraphQL\Schema\Domain\Content\Worker\ContentTypeGroup\AddDomainGroupToDomain;
-use spec\Ibexa\GraphQL\Tools\FieldArgument;
-use Ibexa\Core\Repository\Values\ContentType\ContentTypeGroup;
 use Prophecy\Argument;
+use spec\Ibexa\GraphQL\Tools\FieldArgument;
 
 class AddDomainGroupToDomainSpec extends ContentTypeGroupWorkerBehavior
 {
-    const DOMAIN_TYPE = 'Domain';
-    const GROUP_TYPE = 'DomainGroupTestGroup';
-    const GROUP_FIELD = 'testGroup';
+    public const DOMAIN_TYPE = 'Domain';
+    public const GROUP_TYPE = 'DomainGroupTestGroup';
+    public const GROUP_FIELD = 'testGroup';
 
-    public function let(NameHelper $nameHelper, ContentTypeService $contentTypeService)
+    public function let(NameHelper $nameHelper, ContentTypeService $contentTypeService): void
     {
         $this->beConstructedWith($contentTypeService);
         $this->setNameHelper($nameHelper);
@@ -30,40 +35,36 @@ class AddDomainGroupToDomainSpec extends ContentTypeGroupWorkerBehavior
             ->willReturn(self::GROUP_FIELD);
     }
 
-    function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(AddDomainGroupToDomain::class);
     }
 
-    function it_can_not_work_if_args_do_not_have_ContentTypeGroup(
+    public function it_can_not_work_if_args_do_not_have_ContentTypeGroup(
         SchemaBuilder $schema
-    )
-    {
+    ): void {
         $this->canWork($schema, [])->shouldBe(false);
     }
 
-    function it_can_not_work_if_the_field_is_already_defined(
+    public function it_can_not_work_if_the_field_is_already_defined(
         SchemaBuilder $schema
-    )
-    {
+    ): void {
         $schema->hasTypeWithField(self::DOMAIN_TYPE, self::GROUP_FIELD)->willReturn(true);
         $this->canWork($schema, $this->args())->shouldBe(false);
     }
 
-    function it_can_not_work_if_the_group_is_empty(
+    public function it_can_not_work_if_the_group_is_empty(
         SchemaBuilder $schema,
         ContentTypeService $contentTypeService
-    )
-    {
+    ): void {
         $schema->hasTypeWithField(self::DOMAIN_TYPE, self::GROUP_FIELD)->willReturn(false);
         $contentTypeService->loadContentTypes(Argument::type(ContentTypeGroup::class))->willReturn([]);
         $this->canWork($schema, $this->args())->shouldBe(false);
     }
 
-    function it_adds_a_field_for_the_group_to_the_Domain_object(
+    public function it_adds_a_field_for_the_group_to_the_Domain_object(
         SchemaBuilder $schema
-    )
-    {
+    ): void {
         $schema
             ->addFieldToType(
                 self::DOMAIN_TYPE,

--- a/spec/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroupSpec.php
+++ b/spec/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroupSpec.php
@@ -1,22 +1,27 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
 namespace spec\Ibexa\GraphQL\Schema\Domain\Content\Worker\ContentTypeGroup;
 
 use Ibexa\Contracts\Core\Repository\ContentTypeService;
+use Ibexa\Core\Repository\Values\ContentType\ContentTypeGroup;
 use Ibexa\GraphQL\Schema\Builder\SchemaBuilder;
 use Ibexa\GraphQL\Schema\Domain\Content\NameHelper;
 use Ibexa\GraphQL\Schema\Domain\Content\Worker\ContentTypeGroup\DefineDomainGroup;
+use Prophecy\Argument;
 use spec\Ibexa\GraphQL\Tools\FieldArgument;
 use spec\Ibexa\GraphQL\Tools\TypeArgument;
-use Ibexa\Core\Repository\Values\ContentType\ContentTypeGroup;
-use Prophecy\Argument;
 
 class DefineDomainGroupSpec extends ContentTypeGroupWorkerBehavior
 {
-    const GROUP_TYPE = 'DomainGroupTest';
-    const GROUP_TYPES_TYPE = 'DomainGroupTestTypes';
+    public const GROUP_TYPE = 'DomainGroupTest';
+    public const GROUP_TYPES_TYPE = 'DomainGroupTestTypes';
 
-    public function let(NameHelper $nameHelper, ContentTypeService $contentTypeService)
+    public function let(NameHelper $nameHelper, ContentTypeService $contentTypeService): void
     {
         $this->beConstructedWith($contentTypeService);
         $this->setNameHelper($nameHelper);
@@ -30,40 +35,36 @@ class DefineDomainGroupSpec extends ContentTypeGroupWorkerBehavior
             ->willReturn(self::GROUP_TYPES_TYPE);
     }
 
-    function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(DefineDomainGroup::class);
     }
 
-    function it_can_not_work_if_args_do_not_have_ContentTypeGroup(
+    public function it_can_not_work_if_args_do_not_have_ContentTypeGroup(
         SchemaBuilder $schema
-    )
-    {
+    ): void {
         $this->canWork($schema, [])->shouldBe(false);
     }
 
-    function it_can_not_work_if_the_type_is_already_defined(
+    public function it_can_not_work_if_the_type_is_already_defined(
         SchemaBuilder $schema
-    )
-    {
+    ): void {
         $schema->hasType(self::GROUP_TYPE)->willReturn(true);
         $this->canWork($schema, $this->args())->shouldBe(false);
     }
 
-    function it_can_not_work_if_the_group_is_empty(
+    public function it_can_not_work_if_the_group_is_empty(
         SchemaBuilder $schema,
         ContentTypeService $contentTypeService
-    )
-    {
+    ): void {
         $schema->hasType(self::GROUP_TYPE)->willReturn(true);
         $contentTypeService->loadContentTypes(Argument::type(ContentTypeGroup::class))->willReturn([]);
         $this->canWork($schema, $this->args())->shouldBe(false);
     }
 
-    function it_defines_the_DomainGroup_object(
+    public function it_defines_the_DomainGroup_object(
         SchemaBuilder $schema
-    )
-    {
+    ): void {
         $schema
             ->addType(
                 Argument::allOf(

--- a/spec/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroupTypesSpec.php
+++ b/spec/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroupTypesSpec.php
@@ -1,20 +1,25 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
 namespace spec\Ibexa\GraphQL\Schema\Domain\Content\Worker\ContentTypeGroup;
 
 use Ibexa\Contracts\Core\Repository\ContentTypeService;
+use Ibexa\Core\Repository\Values\ContentType\ContentTypeGroup;
 use Ibexa\GraphQL\Schema\Builder\SchemaBuilder;
 use Ibexa\GraphQL\Schema\Domain\Content\NameHelper;
 use Ibexa\GraphQL\Schema\Domain\Content\Worker\ContentTypeGroup\DefineDomainGroupTypes;
-use spec\Ibexa\GraphQL\Tools\TypeArgument;
-use Ibexa\Core\Repository\Values\ContentType\ContentTypeGroup;
 use Prophecy\Argument;
+use spec\Ibexa\GraphQL\Tools\TypeArgument;
 
 class DefineDomainGroupTypesSpec extends ContentTypeGroupWorkerBehavior
 {
-    const GROUP_TYPES_TYPE = 'DomainGroupTestTypes';
+    public const GROUP_TYPES_TYPE = 'DomainGroupTestTypes';
 
-    public function let(NameHelper $nameHelper, ContentTypeService $contentTypeService)
+    public function let(NameHelper $nameHelper, ContentTypeService $contentTypeService): void
     {
         $this->beConstructedWith($contentTypeService);
         $this->setNameHelper($nameHelper);
@@ -24,40 +29,36 @@ class DefineDomainGroupTypesSpec extends ContentTypeGroupWorkerBehavior
             ->willReturn(self::GROUP_TYPES_TYPE);
     }
 
-    function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(DefineDomainGroupTypes::class);
     }
 
-    function it_can_not_work_if_args_do_not_have_ContentTypeGroup(
+    public function it_can_not_work_if_args_do_not_have_ContentTypeGroup(
         SchemaBuilder $schema
-    )
-    {
+    ): void {
         $this->canWork($schema, [])->shouldBe(false);
     }
 
-    function it_can_not_work_if_the_type_is_already_defined(
+    public function it_can_not_work_if_the_type_is_already_defined(
         SchemaBuilder $schema
-    )
-    {
+    ): void {
         $schema->hasType(self::GROUP_TYPES_TYPE)->willReturn(true);
         $this->canWork($schema, $this->args())->shouldBe(false);
     }
 
-    function it_can_not_work_if_the_group_is_empty(
+    public function it_can_not_work_if_the_group_is_empty(
         SchemaBuilder $schema,
         ContentTypeService $contentTypeService
-    )
-    {
+    ): void {
         $schema->hasType(self::GROUP_TYPES_TYPE)->willReturn(false);
         $contentTypeService->loadContentTypes(Argument::type(ContentTypeGroup::class))->willReturn([]);
         $this->canWork($schema, $this->args())->shouldBe(false);
     }
 
-    function it_defines_the_DomainGroupTypes_object(
+    public function it_defines_the_DomainGroupTypes_object(
         SchemaBuilder $schema
-    )
-    {
+    ): void {
         $schema
             ->addType(
                 Argument::allOf(

--- a/spec/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToItemTypeSpec.php
+++ b/spec/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToItemTypeSpec.php
@@ -1,28 +1,34 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
 namespace spec\Ibexa\GraphQL\Schema\Domain\Content\Worker\FieldDefinition;
 
 use Ibexa\Contracts\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionMapper;
+use Ibexa\Core\Repository\Values\ContentType;
+use Ibexa\Core\Repository\Values\ContentType\FieldDefinition;
+use Ibexa\GraphQL\Schema\Builder;
 use Ibexa\GraphQL\Schema\Domain\Content\NameHelper;
 use Ibexa\GraphQL\Schema\Domain\Content\Worker\FieldDefinition\AddFieldDefinitionToItemType;
-use Ibexa\GraphQL\Schema\Builder;
-use spec\Ibexa\GraphQL\Tools\FieldArgument;
-use Ibexa\Core\Repository\Values\ContentType;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use spec\Ibexa\GraphQL\Tools\FieldArgument;
 
 class AddFieldDefinitionToItemTypeSpec extends ObjectBehavior
 {
-    const TYPE_IDENTIFIER = 'test';
-    const TYPE_NAME = 'TestItemType';
-    const FIELD_IDENTIFIER = 'test_field';
-    const FIELD_NAME = 'testField';
-    const FIELD_DESCRIPTION = ['eng-GB' => 'Description'];
-    const FIELD_TYPE = 'ezstring';
-    const FIELD_DEFINITION_TYPE = 'TestFieldDefinition';
+    public const TYPE_IDENTIFIER = 'test';
+    public const TYPE_NAME = 'TestItemType';
+    public const FIELD_IDENTIFIER = 'test_field';
+    public const FIELD_NAME = 'testField';
+    public const FIELD_DESCRIPTION = ['eng-GB' => 'Description'];
+    public const FIELD_TYPE = 'ezstring';
+    public const FIELD_DEFINITION_TYPE = 'TestFieldDefinition';
 
     /**
-     * @var ContentType\FieldDefinition
+     * @var \Ibexa\Core\Repository\Values\ContentType\FieldDefinition
      */
     private $defaultFieldDefinition;
 
@@ -31,7 +37,7 @@ class AddFieldDefinitionToItemTypeSpec extends ObjectBehavior
         $this->defaultFieldDefinition = $this->buildFieldDefinition(self::FIELD_TYPE);
     }
 
-    function let(FieldDefinitionMapper $mapper, NameHelper $nameHelper)
+    public function let(FieldDefinitionMapper $mapper, NameHelper $nameHelper): void
     {
         $this->beConstructedWith($mapper);
 
@@ -43,19 +49,19 @@ class AddFieldDefinitionToItemTypeSpec extends ObjectBehavior
 
         $nameHelper
             ->fieldDefinitionField(
-                Argument::type(ContentType\FieldDefinition::class)
+                Argument::type(FieldDefinition::class)
             )
             ->willReturn(self::FIELD_NAME);
 
         $this->setNameHelper($nameHelper);
     }
 
-    function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(AddFieldDefinitionToItemType::class);
     }
 
-    function it_adds_the_field_definition_to_the_domain_content_type(Builder $schema)
+    public function it_adds_the_field_definition_to_the_domain_content_type(Builder $schema): void
     {
         $this->work($schema, $this->buildArguments());
 
@@ -65,7 +71,7 @@ class AddFieldDefinitionToItemTypeSpec extends ObjectBehavior
         )->shouldHaveBeenCalled();
     }
 
-    function it_uses_the_FieldDefinition_description_as_the_Field_description(Builder $schema)
+    public function it_uses_the_FieldDefinition_description_as_the_Field_description(Builder $schema): void
     {
         $this->work($schema, $this->buildArguments());
 
@@ -75,7 +81,7 @@ class AddFieldDefinitionToItemTypeSpec extends ObjectBehavior
         )->shouldHaveBeenCalled();
     }
 
-    function it_gets_the_FieldDefinition_type_from_the_FieldDefinitionMapper(Builder $schema, FieldDefinitionMapper $mapper)
+    public function it_gets_the_FieldDefinition_type_from_the_FieldDefinitionMapper(Builder $schema, FieldDefinitionMapper $mapper): void
     {
         $mapper->mapToFieldDefinitionType(Argument::any())->willReturn(self::FIELD_DEFINITION_TYPE);
         $schema->addFieldToType(
@@ -91,15 +97,15 @@ class AddFieldDefinitionToItemTypeSpec extends ObjectBehavior
         $return = [
             'ContentTypeGroup' => new ContentType\ContentTypeGroup(),
             'ContentType' => new ContentType\ContentType(['identifier' => self::TYPE_IDENTIFIER]),
-            'FieldDefinition' => $fieldTypeIdentifier ? $this->buildFieldDefinition($fieldTypeIdentifier) : $this->defaultFieldDefinition
+            'FieldDefinition' => $fieldTypeIdentifier ? $this->buildFieldDefinition($fieldTypeIdentifier) : $this->defaultFieldDefinition,
         ];
 
         return $return;
     }
 
-    private function buildFieldDefinition($fieldTypeIdentifier)
+    private function buildFieldDefinition($fieldTypeIdentifier): FieldDefinition
     {
-        return new ContentType\FieldDefinition([
+        return new FieldDefinition([
             'identifier' => self::FIELD_IDENTIFIER,
             'descriptions' => self::FIELD_DESCRIPTION,
             'fieldTypeIdentifier' => $fieldTypeIdentifier,

--- a/spec/Schema/Domain/Content/Worker/FieldDefinition/AddFieldValueToItemSpec.php
+++ b/spec/Schema/Domain/Content/Worker/FieldDefinition/AddFieldValueToItemSpec.php
@@ -1,27 +1,30 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
 namespace spec\Ibexa\GraphQL\Schema\Domain\Content\Worker\FieldDefinition;
 
-use Ibexa\GraphQL\Schema\Domain\Content\FieldValueBuilder\FieldValueBuilder;
 use Ibexa\Contracts\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionMapper;
+use Ibexa\Core\Repository\Values\ContentType;
+use Ibexa\GraphQL\Schema\Builder;
 use Ibexa\GraphQL\Schema\Domain\Content\NameHelper;
 use Ibexa\GraphQL\Schema\Domain\Content\Worker\FieldDefinition\AddFieldValueToItem;
-use Ibexa\GraphQL\Schema\Builder;
-use spec\Ibexa\GraphQL\Tools\FieldArgument;
-use Ibexa\Core\Repository\Values\ContentType;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use spec\Ibexa\GraphQL\Tools\FieldArgument;
 
 class AddFieldValueToItemSpec extends ObjectBehavior
 {
-    const FIELDTYPE_IDENTIFIER = 'field';
-    const FIELD_IDENTIFIER = 'test';
+    public const FIELDTYPE_IDENTIFIER = 'field';
+    public const FIELD_IDENTIFIER = 'test';
 
-    function let(
+    public function let(
         NameHelper $nameHelper,
         FieldDefinitionMapper $mapper
-    )
-    {
+    ): void {
         $this->beConstructedWith($mapper);
         $this->setNameHelper($nameHelper);
 
@@ -29,16 +32,15 @@ class AddFieldValueToItemSpec extends ObjectBehavior
         $nameHelper->fieldDefinitionField(Argument::any())->willReturn('test');
     }
 
-    function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(AddFieldValueToItem::class);
     }
-    
-    function it_adds_to_the_schema_what_was_returned_by_the_builder(
+
+    public function it_adds_to_the_schema_what_was_returned_by_the_builder(
         Builder $schema,
         FieldDefinitionMapper $mapper
-    )
-    {
+    ): void {
         $mapper->mapToFieldValueType(Argument::any())->willReturn('String');
         $mapper->mapToFieldValueResolver(Argument::any())->willReturn('field');
         $mapper->mapToFieldValueArgsBuilder(Argument::any())->willReturn(null);
@@ -54,13 +56,13 @@ class AddFieldValueToItemSpec extends ObjectBehavior
         $this->work($schema, $this->buildArguments());
     }
 
-    private function buildArguments($fieldTypeIdentifier = self::FIELDTYPE_IDENTIFIER)
+    private function buildArguments($fieldTypeIdentifier = self::FIELDTYPE_IDENTIFIER): array
     {
         return [
             'ContentTypeGroup' => new ContentType\ContentTypeGroup(),
             'ContentType' => new ContentType\ContentType(),
             'FieldDefinition' => new ContentType\FieldDefinition([
-                'fieldTypeIdentifier' => $fieldTypeIdentifier
+                'fieldTypeIdentifier' => $fieldTypeIdentifier,
             ]),
         ];
     }

--- a/spec/Schema/Domain/NameValidatorSpec.php
+++ b/spec/Schema/Domain/NameValidatorSpec.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 declare(strict_types=1);
 
 namespace spec\Ibexa\GraphQL\Schema\Domain;
@@ -9,16 +13,15 @@ use PhpSpec\ObjectBehavior;
 
 final class NameValidatorSpec extends ObjectBehavior
 {
-    function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(NameValidator::class);
     }
 
-    function it_validates_names()
+    public function it_validates_names(): void
     {
         $this->isValidName('777')->shouldBe(false);
         $this->isValidName('foo')->shouldBe(true);
         $this->isValidName('foo_213')->shouldBe(true);
     }
 }
-

--- a/spec/Schema/GeneratorSpec.php
+++ b/spec/Schema/GeneratorSpec.php
@@ -1,25 +1,30 @@
 <?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
 namespace spec\Ibexa\GraphQL\Schema;
 
 use Ibexa\GraphQL\Schema;
-use spec\Ibexa\GraphQL\Tools\Stubs\InitializableWorker;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use spec\Ibexa\GraphQL\Tools\Stubs\InitializableWorker;
 
 class GeneratorSpec extends ObjectBehavior
 {
-    function let(
+    public function let(
         Schema\Builder $schema,
         Schema\Domain\Iterator $iterator,
         Schema\Domain\Iterator $iterator2,
         InitializableWorker $worker1,
         Schema\Worker $worker2
-    )
-    {
-        $iterator->iterate()->will(function() { yield []; });
+    ): void {
+        $iterator->iterate()->will(static function () { yield []; });
         $iterator->init($schema)->willReturn(null);
 
-        $iterator2->iterate()->will(function() { yield []; });
+        $iterator2->iterate()->will(static function () { yield []; });
         $iterator2->init($schema)->willReturn(null);
 
         $schema->getSchema()->willReturn([]);
@@ -31,17 +36,16 @@ class GeneratorSpec extends ObjectBehavior
         $this->beConstructedWith($schema, [$iterator, $iterator2], [$worker1, $worker2]);
     }
 
-    function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(Schema\Generator::class);
     }
 
-    function it_calls_init_on_each_iterator(
+    public function it_calls_init_on_each_iterator(
         Schema\Builder $schema,
         Schema\Domain\Iterator $iterator,
         Schema\Domain\Iterator $iterator2
-    )
-    {
+    ): void {
         $iterator->init($schema)->shouldBeCalled();
         $iterator->iterate()->shouldBeCalled();
 
@@ -51,18 +55,17 @@ class GeneratorSpec extends ObjectBehavior
         $this->generate();
     }
 
-    function it_passes_arguments_from_iterators_to_workers(
+    public function it_passes_arguments_from_iterators_to_workers(
         Schema\Domain\Iterator $iterator,
         Schema\Worker $worker1,
         Schema\Worker $worker2,
         Schema\Builder $schema
-    )
-    {
+    ): void {
         $arguments = [
             ['1_arg' => 'value'],
-            ['2_arg' => 'value']
+            ['2_arg' => 'value'],
         ];
-        $iterator->iterate()->will(function () use ($arguments) {
+        $iterator->iterate()->will(static function () use ($arguments) {
             foreach($arguments as $args) {
                 yield $args;
             }
@@ -90,11 +93,10 @@ class GeneratorSpec extends ObjectBehavior
         $this->generate();
     }
 
-    function it_calls_init_on_schema_initializer_workers(
+    public function it_calls_init_on_schema_initializer_workers(
         Schema\Builder $schema,
         InitializableWorker $worker1
-    )
-    {
+    ): void {
         $worker1->init($schema)->shouldBeCalled();
         $this->generate();
     }

--- a/spec/Schema/GeneratorSpec.php
+++ b/spec/Schema/GeneratorSpec.php
@@ -22,10 +22,10 @@ class GeneratorSpec extends ObjectBehavior
         Schema\Worker $worker2
     ): void {
         $iterator->iterate()->will(static function () { yield []; });
-        $iterator->init($schema)->willReturn(null);
+        $iterator->init($schema)->hasReturnVoid();
 
         $iterator2->iterate()->will(static function () { yield []; });
-        $iterator2->init($schema)->willReturn(null);
+        $iterator2->init($schema)->hasReturnVoid();
 
         $schema->getSchema()->willReturn([]);
 

--- a/spec/Tools/ContentTypeArgument.php
+++ b/spec/Tools/ContentTypeArgument.php
@@ -1,4 +1,10 @@
 <?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
 namespace spec\Ibexa\GraphQL\Tools;
 
 use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
@@ -9,10 +15,10 @@ class ContentTypeArgument
     /**
      * @return \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType|\Prophecy\Argument\Token\CallbackToken
      */
-    public static function withIdentifier($identifier)
+    public static function withIdentifier($identifier): CallbackToken
     {
         return new CallbackToken(
-            function ($argument) use ($identifier) {
+            static function ($argument) use ($identifier): bool {
                 return
                     $argument instanceof ContentType
                     && $argument->identifier === $identifier;

--- a/spec/Tools/ContentTypeGroupArgument.php
+++ b/spec/Tools/ContentTypeGroupArgument.php
@@ -1,4 +1,10 @@
 <?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
 namespace spec\Ibexa\GraphQL\Tools;
 
 use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeGroup;
@@ -9,10 +15,10 @@ class ContentTypeGroupArgument
     /**
      * @return \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeGroup|\Prophecy\Argument\Token\CallbackToken
      */
-    public static function withIdentifier($identifier)
+    public static function withIdentifier($identifier): CallbackToken
     {
         return new CallbackToken(
-            function ($argument) use ($identifier) {
+            static function ($argument) use ($identifier): bool {
                 return
                     $argument instanceof ContentTypeGroup
                     && $argument->identifier === $identifier;

--- a/spec/Tools/EnumValueArgument.php
+++ b/spec/Tools/EnumValueArgument.php
@@ -1,4 +1,10 @@
 <?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
 namespace spec\Ibexa\GraphQL\Tools;
 
 use Ibexa\GraphQL\Schema\Builder\Input;
@@ -6,25 +12,28 @@ use Prophecy\Argument\Token\CallbackToken;
 
 class EnumValueArgument
 {
-    public static function withName($name) {
+    public static function withName($name): CallbackToken
+    {
         return new CallbackToken(
-            function (Input\EnumValue $input) use($name) {
+            static function (Input\EnumValue $input) use ($name): bool {
                 return $input->name === $name;
             }
         );
     }
 
-    public static function withDescription($description) {
+    public static function withDescription($description): CallbackToken
+    {
         return new CallbackToken(
-            function (Input\EnumValue $input) use($description) {
+            static function (Input\EnumValue $input) use ($description): bool {
                 return $input->description === $description;
             }
         );
     }
 
-    public static function withValue($value) {
+    public static function withValue($value): CallbackToken
+    {
         return new CallbackToken(
-            function (Input\EnumValue $input) use($value) {
+            static function (Input\EnumValue $input) use ($value): bool {
                 return $input->value === $value;
             }
         );

--- a/spec/Tools/FieldArgArgument.php
+++ b/spec/Tools/FieldArgArgument.php
@@ -1,4 +1,10 @@
 <?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
 namespace spec\Ibexa\GraphQL\Tools;
 
 use Ibexa\GraphQL\Schema\Builder\Input;
@@ -21,9 +27,10 @@ class FieldArgArgument
         return self::has('type', $type);
     }
 
-    private static function has($property, $value) {
+    private static function has(string $property, $value): CallbackToken
+    {
         return new CallbackToken(
-            function(Input\Arg $arg) use ($property, $value) {
+            static function (Input\Arg $arg) use ($property, $value): bool {
                 return $arg->$property === $value;
             }
         );

--- a/spec/Tools/FieldArgument.php
+++ b/spec/Tools/FieldArgument.php
@@ -1,4 +1,10 @@
 <?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
 namespace spec\Ibexa\GraphQL\Tools;
 
 use Ibexa\GraphQL\Schema\Builder\Input;
@@ -21,18 +27,19 @@ class FieldArgument
         return self::has('description', $description);
     }
 
-    public static function withResolver($resolverFunction)
+    public static function withResolver($resolverFunction): CallbackToken
     {
         return new CallbackToken(
-            function(Input\Field $input) use ($resolverFunction) {
+            static function (Input\Field $input) use ($resolverFunction): bool {
                 return strpos($input->resolve, $resolverFunction) !== false;
             }
         );
     }
 
-    private static function has($property, $value) {
+    private static function has(string $property, $value): CallbackToken
+    {
         return new CallbackToken(
-            function(Input\Field $field) use ($property, $value) {
+            static function (Input\Field $field) use ($property, $value): bool {
                 return $field->$property === $value;
             }
         );

--- a/spec/Tools/SchemaArgument.php
+++ b/spec/Tools/SchemaArgument.php
@@ -1,15 +1,21 @@
 <?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
 namespace spec\Ibexa\GraphQL\Tools;
 
-use PhpSpec\Wrapper\ObjectWrapper;
 use Prophecy\Argument;
+use Prophecy\Argument\Token\CallbackToken;
 
 class SchemaArgument extends Argument
 {
-    public static function isSchema()
+    public static function isSchema(): CallbackToken
     {
-        return new Argument\Token\CallbackToken(
-            function ($schema) {
+        return new CallbackToken(
+            static function ($schema): bool {
                 return is_array($schema);
             }
         );

--- a/spec/Tools/TypeArgument.php
+++ b/spec/Tools/TypeArgument.php
@@ -1,4 +1,10 @@
 <?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
 namespace spec\Ibexa\GraphQL\Tools;
 
 use Ibexa\GraphQL\Schema\Builder\Input;
@@ -6,17 +12,19 @@ use Prophecy\Argument\Token\CallbackToken;
 
 class TypeArgument
 {
-    public static function isNamed($name) {
+    public static function isNamed($name): CallbackToken
+    {
         return new CallbackToken(
-            function (Input\Type $type) use($name) {
+            static function (Input\Type $type) use ($name): bool {
                 return $type->name === $name;
             }
         );
     }
 
-    public static function inherits($typeName) {
+    public static function inherits($typeName): CallbackToken
+    {
         return new CallbackToken(
-            function (Input\type $typeInput) use($typeName) {
+            static function (Input\type $typeInput) use ($typeName): bool {
                 return
                     is_array($typeInput->inherits)
                     ? in_array($typeName, $typeInput->inherits)
@@ -25,10 +33,10 @@ class TypeArgument
         );
     }
 
-    public static function implements($interfaceName)
+    public static function implements($interfaceName): CallbackToken
     {
         return new CallbackToken(
-            function (Input\type $typeInput) use($interfaceName) {
+            static function (Input\type $typeInput) use ($interfaceName): bool {
                 return
                     is_array($typeInput->interfaces)
                         ? in_array($interfaceName, $typeInput->interfaces)
@@ -37,10 +45,10 @@ class TypeArgument
         );
     }
 
-    public static function hasType($expectedType)
+    public static function hasType($expectedType): CallbackToken
     {
         return new CallbackToken(
-            function (Input\Type $type) use($expectedType) {
+            static function (Input\Type $type) use ($expectedType): bool {
                 return $type->type === $expectedType;
             }
         );

--- a/spec/Tools/WorkerArgument.php
+++ b/spec/Tools/WorkerArgument.php
@@ -1,8 +1,15 @@
 <?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
 namespace spec\Ibexa\GraphQL\Tools;
 
 use PhpSpec\Wrapper\ObjectWrapper;
 use Prophecy\Argument;
+use Prophecy\Argument\Token\CallbackToken;
 
 class WorkerArgument extends Argument
 {
@@ -21,13 +28,14 @@ class WorkerArgument extends Argument
         return self::hasArgument('FieldDefinition', $fieldDefinition);
     }
 
-    public static function hasArgument($argumentName, $value = null)
+    public static function hasArgument($argumentName, $value = null): CallbackToken
     {
-        return new Argument\Token\CallbackToken(
-            function ($args) use ($argumentName, $value) {
+        return new CallbackToken(
+            static function ($args) use ($argumentName, $value): bool {
                 if ($value instanceof ObjectWrapper) {
                     $value = $value->getWrappedObject();
                 }
+
                 return isset($args[$argumentName]) && ($value === null || $args[$argumentName] == $value);
             }
         );

--- a/src/bundle/Command/GeneratePlatformSchemaCommand.php
+++ b/src/bundle/Command/GeneratePlatformSchemaCommand.php
@@ -24,17 +24,11 @@ use Symfony\Component\Yaml\Yaml;
 )]
 class GeneratePlatformSchemaCommand extends Command
 {
-    /**
-     * @var \Ibexa\GraphQL\Schema\Generator
-     */
-    private $generator;
+    private Generator $generator;
 
     private Repository $repository;
 
-    /**
-     * @var string
-     */
-    private $schemaRootDir;
+    private string $schemaRootDir;
 
     public function __construct(Generator $generator, Repository $repository, string $schemaRootDir)
     {
@@ -94,7 +88,7 @@ class GeneratePlatformSchemaCommand extends Command
         return Command::SUCCESS;
     }
 
-    private function compileTypes(OutputInterface $output)
+    private function compileTypes(OutputInterface $output): void
     {
         $command = $this->getApplication()->find('graphql:compile');
         $command->run(new StringInput('graphql:compile'), $output);

--- a/src/bundle/DependencyInjection/Compiler/FieldInputHandlersPass.php
+++ b/src/bundle/DependencyInjection/Compiler/FieldInputHandlersPass.php
@@ -17,7 +17,7 @@ class FieldInputHandlersPass implements CompilerPassInterface
 {
     private const FIELD_TYPE_INPUT_HANDLER_TAG = 'ibexa.graphql.field_type.input.handler';
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->has(DomainContentMutationResolver::class)) {
             return;

--- a/src/bundle/DependencyInjection/Compiler/RichTextInputConvertersPass.php
+++ b/src/bundle/DependencyInjection/Compiler/RichTextInputConvertersPass.php
@@ -16,7 +16,7 @@ class RichTextInputConvertersPass implements CompilerPassInterface
 {
     private const RICHTEXT_INPUT_CONVERTER_TAG = 'ibexa.graphql.richtext.input.converter';
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->has(RichTextInputHandler::class)) {
             return;

--- a/src/bundle/DependencyInjection/Compiler/SchemaDomainIteratorsPass.php
+++ b/src/bundle/DependencyInjection/Compiler/SchemaDomainIteratorsPass.php
@@ -14,7 +14,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class SchemaDomainIteratorsPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->has(Generator::class)) {
             return;

--- a/src/bundle/DependencyInjection/Compiler/SchemaWorkersPass.php
+++ b/src/bundle/DependencyInjection/Compiler/SchemaWorkersPass.php
@@ -14,7 +14,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class SchemaWorkersPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->has(Generator::class)) {
             return;

--- a/src/bundle/DependencyInjection/GraphQL/YamlSchemaProvider.php
+++ b/src/bundle/DependencyInjection/GraphQL/YamlSchemaProvider.php
@@ -20,17 +20,15 @@ class YamlSchemaProvider implements SchemaProvider
 
     /**
      * The path to the graphql configuration root.
-     *
-     * @var string
      */
-    private $root;
+    private string $root;
 
     public function __construct($graphQLConfigRoot)
     {
         $this->root = rtrim($graphQLConfigRoot, '/') . '/';
     }
 
-    public function getSchemaConfiguration()
+    public function getSchemaConfiguration(): array
     {
         return [
             'query' => $this->getQuerySchema(),
@@ -39,7 +37,7 @@ class YamlSchemaProvider implements SchemaProvider
         ];
     }
 
-    private function getQuerySchema()
+    private function getQuerySchema(): string
     {
         if (file_exists($this->getAppQuerySchema())) {
             return 'Query';
@@ -50,7 +48,7 @@ class YamlSchemaProvider implements SchemaProvider
         }
     }
 
-    private function getMutationSchema()
+    private function getMutationSchema(): ?string
     {
         if (file_exists($this->getAppMutationSchemaFile())) {
             return 'Mutation';
@@ -61,22 +59,22 @@ class YamlSchemaProvider implements SchemaProvider
         }
     }
 
-    private function getAppQuerySchema()
+    private function getAppQuerySchema(): string
     {
         return $this->root . self::APP_QUERY_SCHEMA_FILE;
     }
 
-    private function getAppMutationSchemaFile()
+    private function getAppMutationSchemaFile(): string
     {
         return $this->root . self::APP_MUTATION_SCHEMA_FILE;
     }
 
-    private function getPlatformQuerySchema()
+    private function getPlatformQuerySchema(): string
     {
         return $this->root . self::DXP_SCHEMA_FILE;
     }
 
-    private function getPlatformMutationSchema()
+    private function getPlatformMutationSchema(): string
     {
         return $this->root . self::DXP_MUTATION_FILE;
     }

--- a/src/bundle/DependencyInjection/IbexaGraphQLExtension.php
+++ b/src/bundle/DependencyInjection/IbexaGraphQLExtension.php
@@ -38,7 +38,7 @@ class IbexaGraphQLExtension extends Extension implements PrependExtensionInterfa
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
@@ -58,7 +58,7 @@ class IbexaGraphQLExtension extends Extension implements PrependExtensionInterfa
     /**
      * {@inheritdoc}
      */
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
         $this->setContainerParameters($container);
 

--- a/src/bundle/IbexaGraphQLBundle.php
+++ b/src/bundle/IbexaGraphQLBundle.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class IbexaGraphQLBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 

--- a/src/lib/DataLoader/CachedContentLoader.php
+++ b/src/lib/DataLoader/CachedContentLoader.php
@@ -16,10 +16,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
  */
 class CachedContentLoader implements ContentLoader
 {
-    /**
-     * @var \Ibexa\GraphQL\DataLoader\ContentLoader
-     */
-    private $innerLoader;
+    private ContentLoader $innerLoader;
 
     private $loadedItems = [];
 

--- a/src/lib/DataLoader/CachedContentTypeLoader.php
+++ b/src/lib/DataLoader/CachedContentTypeLoader.php
@@ -14,15 +14,12 @@ use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
  */
 class CachedContentTypeLoader implements ContentTypeLoader
 {
-    /**
-     * @var \Ibexa\GraphQL\DataLoader\ContentTypeLoader
-     */
-    private $innerLoader;
+    private ContentTypeLoader $innerLoader;
 
     /**
      * @var \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType[]
      */
-    private $loadedItems = [];
+    private array $loadedItems = [];
 
     public function __construct(ContentTypeLoader $innerLoader)
     {

--- a/src/lib/DataLoader/RepositoryContentTypeLoader.php
+++ b/src/lib/DataLoader/RepositoryContentTypeLoader.php
@@ -15,10 +15,7 @@ use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
  */
 class RepositoryContentTypeLoader implements ContentTypeLoader
 {
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\ContentTypeService
-     */
-    private $contentTypeService;
+    private ContentTypeService $contentTypeService;
 
     public function __construct(ContentTypeService $contentTypeService)
     {

--- a/src/lib/DataLoader/SearchContentLoader.php
+++ b/src/lib/DataLoader/SearchContentLoader.php
@@ -20,10 +20,7 @@ use Ibexa\GraphQL\DataLoader\Exception\ArgumentsException;
  */
 class SearchContentLoader implements ContentLoader
 {
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\SearchService
-     */
-    private $searchService;
+    private SearchService $searchService;
 
     public function __construct(SearchService $searchService)
     {

--- a/src/lib/DataLoader/SearchLocationLoader.php
+++ b/src/lib/DataLoader/SearchLocationLoader.php
@@ -24,30 +24,15 @@ use Ibexa\GraphQL\DataLoader\Exception\ArgumentsException;
  */
 class SearchLocationLoader implements LocationLoader
 {
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\SearchService
-     */
-    private $searchService;
+    private SearchService $searchService;
 
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\LocationService
-     */
-    private $locationService;
+    private LocationService $locationService;
 
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\URLAliasService
-     */
-    private $urlAliasService;
+    private URLAliasService $urlAliasService;
 
-    /**
-     * @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface
-     */
-    private $configResolver;
+    private ConfigResolverInterface $configResolver;
 
-    /**
-     * @var \Ibexa\Core\MVC\Symfony\Routing\Generator\UrlAliasGenerator
-     */
-    private $urlAliasGenerator;
+    private UrlAliasGenerator $urlAliasGenerator;
 
     public function __construct(SearchService $searchService, LocationService $locationService, URLAliasService $urlAliasService, ConfigResolverInterface $configResolver, UrlAliasGenerator $urlAliasGenerator)
     {
@@ -119,7 +104,7 @@ class SearchLocationLoader implements LocationLoader
         }
     }
 
-    protected function getUrlAlias($pathinfo): URLAlias
+    protected function getUrlAlias(string $pathinfo): URLAlias
     {
         $rootLocationId = $this->configResolver->getParameter('content.tree_root.location_id');
         $pathPrefix = $this->urlAliasGenerator->getPathPrefixByRootLocationId($rootLocationId);

--- a/src/lib/Exception/MultipleValidLocationsException.php
+++ b/src/lib/Exception/MultipleValidLocationsException.php
@@ -15,12 +15,9 @@ class MultipleValidLocationsException extends \Exception
     /**
      * @var \Ibexa\Contracts\Core\Repository\Values\Content\Location[]
      */
-    private $locations = [];
+    private array $locations;
 
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\Values\Content\Content
-     */
-    private $content;
+    private Content $content;
 
     /**
      * @param \Ibexa\Contracts\Core\Repository\Values\Content\Content $content

--- a/src/lib/Exception/NoValidLocationsException.php
+++ b/src/lib/Exception/NoValidLocationsException.php
@@ -13,16 +13,8 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 
 class NoValidLocationsException extends Exception
 {
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\Values\Content\Content|\Ibexa\Contracts\Core\Repository\Values\Content\Content[]
-     */
     private Content $content;
 
-    /**
-     * NoValidLocationsException constructor.
-     *
-     * @param \Ibexa\Contracts\Core\Repository\Values\Content\Content $content
-     */
     public function __construct(Content $content)
     {
         parent::__construct("No valid location could be determined for content #{$content->id}");

--- a/src/lib/Exception/NoValidLocationsException.php
+++ b/src/lib/Exception/NoValidLocationsException.php
@@ -16,7 +16,7 @@ class NoValidLocationsException extends Exception
     /**
      * @var \Ibexa\Contracts\Core\Repository\Values\Content\Content|\Ibexa\Contracts\Core\Repository\Values\Content\Content[]
      */
-    private $content;
+    private Content $content;
 
     /**
      * NoValidLocationsException constructor.

--- a/src/lib/Exception/NoValidSiteaccessException.php
+++ b/src/lib/Exception/NoValidSiteaccessException.php
@@ -12,10 +12,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 
 class NoValidSiteaccessException extends Exception
 {
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\Values\Content\Location
-     */
-    private $location;
+    private Location $location;
 
     public function __construct(Location $location)
     {

--- a/src/lib/InputMapper/ContentCollectionFilterBuilder.php
+++ b/src/lib/InputMapper/ContentCollectionFilterBuilder.php
@@ -21,15 +21,9 @@ use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
  */
 class ContentCollectionFilterBuilder
 {
-    /**
-     * @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface
-     */
-    private $configResolver;
+    private ConfigResolverInterface $configResolver;
 
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\Repository
-     */
-    private $repository;
+    private Repository $repository;
 
     public function __construct(ConfigResolverInterface $configResolver, Repository $repository)
     {

--- a/src/lib/InputMapper/SearchQueryMapper.php
+++ b/src/lib/InputMapper/SearchQueryMapper.php
@@ -9,14 +9,12 @@ namespace Ibexa\GraphQL\InputMapper;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\LocationQuery;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\Field;
 use InvalidArgumentException;
 
 final class SearchQueryMapper implements QueryMapper
 {
-    /**
-     * @var \Ibexa\GraphQL\InputMapper\ContentCollectionFilterBuilder
-     */
-    private $filterBuilder;
+    private ContentCollectionFilterBuilder $filterBuilder;
 
     public function __construct(ContentCollectionFilterBuilder $filterBuilder)
     {
@@ -45,7 +43,7 @@ final class SearchQueryMapper implements QueryMapper
         return $query;
     }
 
-    private function mapInput($query, array $inputArray): void
+    private function mapInput(LocationQuery|Query $query, array $inputArray): void
     {
         if (isset($inputArray['offset'])) {
             $query->offset = $inputArray['offset'];
@@ -88,7 +86,7 @@ final class SearchQueryMapper implements QueryMapper
 
         if (isset($inputArray['sortBy'])) {
             $query->sortClauses = array_map(
-                static function ($sortClauseClass) {
+                static function ($sortClauseClass): ?object {
                     /** @var Query\SortClause $lastSortClause */
                     static $lastSortClause;
 
@@ -130,7 +128,7 @@ final class SearchQueryMapper implements QueryMapper
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\DateMetadata[]
      */
-    private function mapDateMetadata(array $queryArg, $dateMetadata)
+    private function mapDateMetadata(array $queryArg, string $dateMetadata): array
     {
         if (!isset($queryArg[$dateMetadata]) || !is_array($queryArg[$dateMetadata])) {
             return [];
@@ -167,7 +165,7 @@ final class SearchQueryMapper implements QueryMapper
         return $criteria;
     }
 
-    private function mapInputToFieldCriterion($input)
+    private function mapInputToFieldCriterion($input): Field
     {
         $operators = ['in', 'eq', 'like', 'contains', 'between', 'lt', 'lte', 'gt', 'gte'];
         foreach ($operators as $opString) {
@@ -181,6 +179,6 @@ final class SearchQueryMapper implements QueryMapper
             throw new InvalidArgumentException('Unspecified operator');
         }
 
-        return new Query\Criterion\Field($input['target'], $operator, $value);
+        return new Field($input['target'], $operator, $value);
     }
 }

--- a/src/lib/InputMapper/SearchQueryMapper.php
+++ b/src/lib/InputMapper/SearchQueryMapper.php
@@ -43,6 +43,19 @@ final class SearchQueryMapper implements QueryMapper
         return $query;
     }
 
+    /**
+     * @param array{
+     *     offset?: int,
+     *     limit?: int,
+     *     ContentTypeIdentifier?: string|string[],
+     *     Text?: string,
+     *     Field?: array<array{target: mixed}>,
+     *     ParentLocationId?: int|int[],
+     *     sortBy?: array<string|\Ibexa\Contracts\Core\Repository\Values\Content\Query::SORT_*>,
+     *     Modified?: array<string, mixed>,
+     *     Created?: array<string, mixed>
+     * } $inputArray
+     */
     private function mapInput(LocationQuery|Query $query, array $inputArray): void
     {
         if (isset($inputArray['offset'])) {
@@ -85,9 +98,9 @@ final class SearchQueryMapper implements QueryMapper
         $criteria = array_merge($criteria, $this->mapDateMetadata($inputArray, 'Created'));
 
         if (isset($inputArray['sortBy'])) {
-            $query->sortClauses = array_map(
+            /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause[]|null[] $sortClauses */
+            $sortClauses = array_map(
                 static function ($sortClauseClass): ?object {
-                    /** @var Query\SortClause $lastSortClause */
                     static $lastSortClause;
 
                     if ($sortClauseClass === Query::SORT_DESC) {
@@ -113,7 +126,7 @@ final class SearchQueryMapper implements QueryMapper
                 $inputArray['sortBy']
             );
             // remove null entries left out because of sort direction
-            $query->sortClauses = array_filter($query->sortClauses);
+            $query->sortClauses = array_filter($sortClauses);
         }
 
         if (count($criteria) === 0) {

--- a/src/lib/InputMapper/SearchQuerySortByMapper.php
+++ b/src/lib/InputMapper/SearchQuerySortByMapper.php
@@ -20,7 +20,6 @@ class SearchQuerySortByMapper
     {
         $sortClauses = array_map(
             static function (string $sortClauseClass): ?object {
-                /** @var Query\SortClause $lastSortClause */
                 static $lastSortClause;
 
                 if ($sortClauseClass === Query::SORT_DESC) {

--- a/src/lib/InputMapper/SearchQuerySortByMapper.php
+++ b/src/lib/InputMapper/SearchQuerySortByMapper.php
@@ -16,10 +16,10 @@ class SearchQuerySortByMapper
      *
      * @return \Ibexa\Contracts\Core\Repository\Values\URL\Query\SortClause[]
      */
-    public function mapInputToSortClauses(array $sortInput)
+    public function mapInputToSortClauses(array $sortInput): array
     {
         $sortClauses = array_map(
-            static function (string $sortClauseClass) {
+            static function (string $sortClauseClass): ?object {
                 /** @var Query\SortClause $lastSortClause */
                 static $lastSortClause;
 

--- a/src/lib/ItemFactory.php
+++ b/src/lib/ItemFactory.php
@@ -9,23 +9,19 @@ namespace Ibexa\GraphQL;
 
 use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\Contracts\Core\Repository\Values\Content\Location;
+use Ibexa\GraphQL\Resolver\LocationGuesser\LocationGuesser;
+use Ibexa\GraphQL\Resolver\SiteaccessGuesser\SiteaccessGuesser;
 use Ibexa\GraphQL\Value\Item;
 
 class ItemFactory
 {
-    /**
-     * @var \Ibexa\GraphQL\Resolver\LocationGuesser\LocationGuesser
-     */
-    private $locationGuesser;
+    private LocationGuesser $locationGuesser;
 
-    /**
-     * @var \Ibexa\GraphQL\Resolver\SiteaccessGuesser\SiteaccessGuesser
-     */
-    private $siteaccessGuesser;
+    private SiteaccessGuesser $siteaccessGuesser;
 
     public function __construct(
-        Resolver\LocationGuesser\LocationGuesser $locationGuesser,
-        Resolver\SiteaccessGuesser\SiteaccessGuesser $siteaccessGuesser
+        LocationGuesser $locationGuesser,
+        SiteaccessGuesser $siteaccessGuesser
     ) {
         $this->locationGuesser = $locationGuesser;
         $this->siteaccessGuesser = $siteaccessGuesser;

--- a/src/lib/Mutation/InputHandler/FieldType/FromHash.php
+++ b/src/lib/Mutation/InputHandler/FieldType/FromHash.php
@@ -16,10 +16,7 @@ use Ibexa\Core\FieldType\FieldType;
  */
 class FromHash implements FieldTypeInputHandler
 {
-    /**
-     * @var \Ibexa\Core\FieldType\FieldType
-     */
-    private $fieldType;
+    private FieldType $fieldType;
 
     public function __construct(FieldType $fieldType)
     {

--- a/src/lib/Mutation/InputHandler/FieldType/RichText.php
+++ b/src/lib/Mutation/InputHandler/FieldType/RichText.php
@@ -17,7 +17,7 @@ class RichText implements FieldTypeInputHandler
     /**
      * @var \Ibexa\Contracts\GraphQL\Mutation\InputHandler\FieldType\RichText\RichTextInputConverter[]
      */
-    private $inputConverters;
+    private array $inputConverters;
 
     public function __construct(array $inputConverters)
     {

--- a/src/lib/Mutation/InputHandler/FieldType/RichText/HtmlRichTextConverter.php
+++ b/src/lib/Mutation/InputHandler/FieldType/RichText/HtmlRichTextConverter.php
@@ -13,8 +13,7 @@ use Ibexa\Contracts\GraphQL\Mutation\InputHandler\FieldType\RichText\RichTextInp
 
 class HtmlRichTextConverter implements RichTextInputConverter
 {
-    /** @var \Ibexa\Contracts\FieldTypeRichText\RichText\Converter */
-    private $xhtml5Converter;
+    private Converter $xhtml5Converter;
 
     public function __construct(Converter $xhtml5Converter)
     {

--- a/src/lib/Mutation/InputHandler/FieldType/RichText/MarkdownRichTextConverter.php
+++ b/src/lib/Mutation/InputHandler/FieldType/RichText/MarkdownRichTextConverter.php
@@ -14,15 +14,11 @@ use Parsedown;
 
 class MarkdownRichTextConverter implements RichTextInputConverter
 {
-    /** @var \Ibexa\Contracts\FieldTypeRichText\RichText\Converter */
-    private Parsedown $markdownConverter;
-
     private Converter $xhtml5Converter;
 
     public function __construct(Converter $xhtml5Converter)
     {
         $this->xhtml5Converter = $xhtml5Converter;
-        $this->markdownConverter = new Parsedown();
     }
 
     public function convertToXml($text): DOMDocument

--- a/src/lib/Mutation/InputHandler/FieldType/RichText/MarkdownRichTextConverter.php
+++ b/src/lib/Mutation/InputHandler/FieldType/RichText/MarkdownRichTextConverter.php
@@ -15,10 +15,9 @@ use Parsedown;
 class MarkdownRichTextConverter implements RichTextInputConverter
 {
     /** @var \Ibexa\Contracts\FieldTypeRichText\RichText\Converter */
-    private $markdownConverter;
+    private Parsedown $markdownConverter;
 
-    /** @var \Ibexa\Contracts\FieldTypeRichText\RichText\Converter */
-    private $xhtml5Converter;
+    private Converter $xhtml5Converter;
 
     public function __construct(Converter $xhtml5Converter)
     {

--- a/src/lib/Mutation/SectionMutation.php
+++ b/src/lib/Mutation/SectionMutation.php
@@ -12,17 +12,14 @@ use Ibexa\Contracts\Core\Repository\Values\Content\SectionCreateStruct;
 
 class SectionMutation
 {
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\SectionService
-     */
-    private $sectionService;
+    private SectionService $sectionService;
 
     public function __construct(SectionService $sectionService)
     {
         $this->sectionService = $sectionService;
     }
 
-    public function createSection($value)
+    public function createSection(array $value)
     {
         $sectionCreateStruct = new SectionCreateStruct(
             [
@@ -61,7 +58,7 @@ class SectionMutation
      *
      * @return array
      */
-    private function mapSectionToPayLoad($value, $section)
+    private function mapSectionToPayLoad(array $value, $section): array
     {
         return [
             'clientMutationId' => $value['clientMutationId'],

--- a/src/lib/Mutation/SectionMutation.php
+++ b/src/lib/Mutation/SectionMutation.php
@@ -8,6 +8,7 @@
 namespace Ibexa\GraphQL\Mutation;
 
 use Ibexa\Contracts\Core\Repository\SectionService;
+use Ibexa\Contracts\Core\Repository\Values\Content\Section;
 use Ibexa\Contracts\Core\Repository\Values\Content\SectionCreateStruct;
 
 class SectionMutation
@@ -19,6 +20,9 @@ class SectionMutation
         $this->sectionService = $sectionService;
     }
 
+    /**
+     * @param array{identifier: string, name: string, clientMutationId: string} $value
+     */
     public function createSection(array $value)
     {
         $sectionCreateStruct = new SectionCreateStruct(
@@ -53,12 +57,16 @@ class SectionMutation
     }
 
     /**
-     * @param $value
-     * @param $section
+     * @param array{clientMutationId: string} $value
      *
-     * @return array
+     * @return array{
+     *     clientMutationId: string,
+     *     id: int,
+     *     identifier: string,
+     *     name: string
+     * }
      */
-    private function mapSectionToPayLoad(array $value, $section): array
+    private function mapSectionToPayLoad(array $value, Section $section): array
     {
         return [
             'clientMutationId' => $value['clientMutationId'],

--- a/src/lib/Mutation/UploadFiles.php
+++ b/src/lib/Mutation/UploadFiles.php
@@ -17,15 +17,9 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class UploadFiles
 {
-    /**
-     * @var \Ibexa\AdminUi\UI\Config\Provider\ContentTypeMappings
-     */
-    private $contentTypeMappings;
+    private ContentTypeMappings $contentTypeMappings;
 
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\Repository
-     */
-    private $repository;
+    private Repository $repository;
 
     public function __construct(Repository $repository, ContentTypeMappings $contentTypeMappings)
     {
@@ -33,7 +27,7 @@ class UploadFiles
         $this->contentTypeMappings = $contentTypeMappings;
     }
 
-    public function uploadFiles(Argument $args)
+    public function uploadFiles(Argument $args): array
     {
         $createdContent = [];
         $warnings = [];
@@ -56,13 +50,13 @@ class UploadFiles
         return ['files' => $createdContent, 'warnings' => $warnings];
     }
 
-    private function mapAgainstConfig($mimeType)
+    private function mapAgainstConfig(?string $mimeType)
     {
         foreach ($this->contentTypeMappings->getConfig()['defaultMappings'] as $mapping) {
             if (in_array($mimeType, $mapping['mimeTypes'])) {
                 return array_filter(
                     $mapping,
-                    static function ($key) {
+                    static function ($key): bool {
                         return in_array($key, ['contentTypeIdentifier', 'contentFieldIdentifier', 'nameFieldIdentifier']);
                     },
                     ARRAY_FILTER_USE_KEY
@@ -78,7 +72,7 @@ class UploadFiles
      * @param $locationId The parent location ID
      * @param $languageCode
      */
-    private function createContent(array $mapping, UploadedFile $file, $locationId, $languageCode): Content
+    private function createContent(array $mapping, UploadedFile $file, int $locationId, string $languageCode): Content
     {
         $contentService = $this->repository->getContentService();
         $locationService = $this->repository->getLocationService();

--- a/src/lib/Mutation/UploadFiles.php
+++ b/src/lib/Mutation/UploadFiles.php
@@ -27,6 +27,9 @@ class UploadFiles
         $this->contentTypeMappings = $contentTypeMappings;
     }
 
+    /**
+     * @return array{files: array<\Ibexa\Contracts\Core\Repository\Values\Content\Content>, warnings: array<string>}
+     */
     public function uploadFiles(Argument $args): array
     {
         $createdContent = [];

--- a/src/lib/Relay/NodeResolver.php
+++ b/src/lib/Relay/NodeResolver.php
@@ -16,25 +16,13 @@ use Overblog\GraphQLBundle\Resolver\TypeResolver;
 
 class NodeResolver
 {
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\ContentService
-     */
-    private $contentService;
+    private ContentService $contentService;
 
-    /**
-     * @var \Overblog\GraphQLBundle\Resolver\TypeResolver
-     */
-    private $typeResolver;
+    private TypeResolver $typeResolver;
 
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\ContentTypeService
-     */
-    private $contentTypeService;
+    private ContentTypeService $contentTypeService;
 
-    /**
-     * @var \Ibexa\GraphQL\Schema\Domain\Content\NameHelper
-     */
-    private $nameHelper;
+    private NameHelper $nameHelper;
 
     public function __construct(ContentService $contentService, TypeResolver $typeResolver, ContentTypeService $contentTypeService, NameHelper $nameHelper)
     {

--- a/src/lib/Relay/SearchResolver.php
+++ b/src/lib/Relay/SearchResolver.php
@@ -23,7 +23,17 @@ class SearchResolver
     }
 
     /**
-     * @param $args
+     * @param array{
+     *     query: array{
+     *         ContentTypeIdentifier?: string|array<string>,
+     *         Text?: array<string>,
+     *     },
+     *     first?: int,
+     *     last?: int,
+     *     after?: string,
+     *     before?: string,
+     *     offset?: int
+     * } $args
      *
      * @return \Overblog\GraphQLBundle\Relay\Connection\ConnectionInterface<\Ibexa\Contracts\Core\Repository\Values\ValueObject>
      *

--- a/src/lib/Relay/SearchResolver.php
+++ b/src/lib/Relay/SearchResolver.php
@@ -15,10 +15,7 @@ use Overblog\GraphQLBundle\Relay\Connection\ConnectionInterface;
 
 class SearchResolver
 {
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\SearchService
-     */
-    private $searchService;
+    private SearchService $searchService;
 
     public function __construct(SearchService $searchService)
     {
@@ -32,7 +29,7 @@ class SearchResolver
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
      */
-    public function searchContent($args): ConnectionInterface
+    public function searchContent(array $args): ConnectionInterface
     {
         $queryArg = $args['query'];
 

--- a/src/lib/Resolver/ContentResolver.php
+++ b/src/lib/Resolver/ContentResolver.php
@@ -22,15 +22,9 @@ use Overblog\GraphQLBundle\Definition\Resolver\QueryInterface;
  */
 class ContentResolver implements QueryInterface
 {
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\ContentService
-     */
-    private $contentService;
+    private ContentService $contentService;
 
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\SearchService
-     */
-    private $searchService;
+    private SearchService $searchService;
 
     public function __construct(ContentService $contentService, SearchService $searchService)
     {
@@ -38,7 +32,7 @@ class ContentResolver implements QueryInterface
         $this->searchService = $searchService;
     }
 
-    public function findContentByType($contentTypeId)
+    public function findContentByType($contentTypeId): array
     {
         $searchResults = $this->searchService->findContentInfo(
             new Query([
@@ -57,7 +51,7 @@ class ContentResolver implements QueryInterface
     /**
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Relation[]
      */
-    public function findContentRelations(ContentInfo $contentInfo, $version = null)
+    public function findContentRelations(ContentInfo $contentInfo, ?int $version = null): array
     {
         return array_filter(array_map(
             static fn (RelationListItemInterface $relationListItem): ?Relation => $relationListItem->getRelation(),
@@ -67,7 +61,7 @@ class ContentResolver implements QueryInterface
         ));
     }
 
-    public function findContentReverseRelations(ContentInfo $contentInfo)
+    public function findContentReverseRelations(ContentInfo $contentInfo): iterable
     {
         return $this->contentService->loadReverseRelations($contentInfo);
     }
@@ -83,12 +77,12 @@ class ContentResolver implements QueryInterface
         }
     }
 
-    public function resolveContentById($contentId)
+    public function resolveContentById(int $contentId): ContentInfo
     {
         return $this->contentService->loadContentInfo($contentId);
     }
 
-    public function resolveContentByIdList(array $contentIdList)
+    public function resolveContentByIdList(array $contentIdList): array
     {
         try {
             $searchResults = $this->searchService->findContentInfo(
@@ -108,7 +102,7 @@ class ContentResolver implements QueryInterface
         );
     }
 
-    public function resolveContentVersions($contentId)
+    public function resolveContentVersions(int $contentId): iterable
     {
         return $this->contentService->loadVersions(
             $this->contentService->loadContentInfo($contentId)

--- a/src/lib/Resolver/ContentResolver.php
+++ b/src/lib/Resolver/ContentResolver.php
@@ -95,6 +95,7 @@ class ContentResolver implements QueryInterface
 
     /**
      * @param array<int> $contentIdList
+     *
      * @return array<\Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo>
      */
     public function resolveContentByIdList(array $contentIdList): array
@@ -119,6 +120,7 @@ class ContentResolver implements QueryInterface
 
     /**
      * @param int $contentId
+     *
      * @return iterable<\Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo>
      */
     public function resolveContentVersions(int $contentId): iterable

--- a/src/lib/Resolver/ContentResolver.php
+++ b/src/lib/Resolver/ContentResolver.php
@@ -7,6 +7,7 @@
 
 namespace Ibexa\GraphQL\Resolver;
 
+use GraphQL\Error\UserError;
 use Ibexa\Contracts\Core\Repository\ContentService;
 use Ibexa\Contracts\Core\Repository\SearchService;
 use Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo;
@@ -32,6 +33,11 @@ class ContentResolver implements QueryInterface
         $this->searchService = $searchService;
     }
 
+    /**
+     * @param int $contentTypeId
+     *
+     * @return array<\Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo>
+     */
     public function findContentByType($contentTypeId): array
     {
         $searchResults = $this->searchService->findContentInfo(
@@ -61,12 +67,15 @@ class ContentResolver implements QueryInterface
         ));
     }
 
+    /**
+     * @return iterable<\Ibexa\Contracts\Core\Repository\Values\Content\Relation>
+     */
     public function findContentReverseRelations(ContentInfo $contentInfo): iterable
     {
         return $this->contentService->loadReverseRelations($contentInfo);
     }
 
-    public function resolveContent($args)
+    public function resolveContent($args): ContentInfo
     {
         if (isset($args['id'])) {
             return $this->contentService->loadContentInfo($args['id']);
@@ -75,6 +84,8 @@ class ContentResolver implements QueryInterface
         if (isset($args['remoteId'])) {
             return $this->contentService->loadContentInfoByRemoteId($args['remoteId']);
         }
+
+        throw new UserError('Either id or remoteId is required as an argument');
     }
 
     public function resolveContentById(int $contentId): ContentInfo
@@ -82,6 +93,10 @@ class ContentResolver implements QueryInterface
         return $this->contentService->loadContentInfo($contentId);
     }
 
+    /**
+     * @param array<int> $contentIdList
+     * @return array<\Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo>
+     */
     public function resolveContentByIdList(array $contentIdList): array
     {
         try {
@@ -102,6 +117,10 @@ class ContentResolver implements QueryInterface
         );
     }
 
+    /**
+     * @param int $contentId
+     * @return iterable<\Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo>
+     */
     public function resolveContentVersions(int $contentId): iterable
     {
         return $this->contentService->loadVersions(

--- a/src/lib/Resolver/ContentThumbnailResolver.php
+++ b/src/lib/Resolver/ContentThumbnailResolver.php
@@ -13,8 +13,7 @@ use Overblog\GraphQLBundle\Definition\Resolver\QueryInterface;
 
 final class ContentThumbnailResolver implements QueryInterface
 {
-    /** @var \Ibexa\Contracts\Core\Repository\Strategy\ContentThumbnail\ThumbnailStrategy */
-    private $thumbnailStrategy;
+    private ThumbnailStrategy $thumbnailStrategy;
 
     public function __construct(
         ThumbnailStrategy $thumbnailStrategy

--- a/src/lib/Resolver/ContentTypeResolver.php
+++ b/src/lib/Resolver/ContentTypeResolver.php
@@ -8,6 +8,8 @@
 namespace Ibexa\GraphQL\Resolver;
 
 use Ibexa\Contracts\Core\Repository\ContentTypeService;
+use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
+use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeGroup;
 use Overblog\GraphQLBundle\Resolver\TypeResolver;
 
 /**
@@ -15,15 +17,9 @@ use Overblog\GraphQLBundle\Resolver\TypeResolver;
  */
 class ContentTypeResolver
 {
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\ContentTypeService
-     */
-    private $contentTypeService;
+    private ContentTypeService $contentTypeService;
 
-    /**
-     * @var \Overblog\GraphQLBundle\Resolver\TypeResolver
-     */
-    private $typeResolver;
+    private TypeResolver $typeResolver;
 
     public function __construct(TypeResolver $typeResolver, ContentTypeService $contentTypeService)
     {
@@ -59,12 +55,12 @@ class ContentTypeResolver
         return $contentTypes;
     }
 
-    public function resolveContentTypeById($contentTypeId)
+    public function resolveContentTypeById(int $contentTypeId): ContentType
     {
         return $this->contentTypeService->loadContentType($contentTypeId);
     }
 
-    public function resolveContentTypeGroupByIdentifier($identifier)
+    public function resolveContentTypeGroupByIdentifier(string $identifier): ContentTypeGroup
     {
         return $this->contentTypeService->loadContentTypeGroupByIdentifier($identifier);
     }

--- a/src/lib/Resolver/DomainContentMutationResolver.php
+++ b/src/lib/Resolver/DomainContentMutationResolver.php
@@ -8,8 +8,11 @@
 namespace Ibexa\GraphQL\Resolver;
 
 use GraphQL\Error\UserError;
-use Ibexa\Contracts\Core\Repository as API;
+use Ibexa\Contracts\Core\Repository\ContentService;
+use Ibexa\Contracts\Core\Repository\ContentTypeService;
 use Ibexa\Contracts\Core\Repository\Exceptions as RepositoryExceptions;
+use Ibexa\Contracts\Core\Repository\LocationService;
+use Ibexa\Contracts\Core\Repository\Repository;
 use Ibexa\Contracts\Core\Repository\Values as RepositoryValues;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
 use Ibexa\GraphQL\Exception\UnsupportedFieldTypeException;
@@ -27,25 +30,21 @@ use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter
 class DomainContentMutationResolver
 {
     /**
-     * @var API\Repository
+     * @var \Ibexa\Contracts\Core\Repository\Repository
      */
-    private $repository;
+    private Repository $repository;
 
     /**
      * @var \Ibexa\Contracts\GraphQL\Mutation\InputHandler\FieldTypeInputHandler[]
      */
-    private $fieldInputHandlers = [];
+    private array $fieldInputHandlers;
 
-    /**
-     * @var \Ibexa\GraphQL\Schema\Domain\Content\NameHelper
-     */
-    private $nameHelper;
+    private NameHelper $nameHelper;
 
-    /** @var \Ibexa\GraphQL\ItemFactory */
-    private $itemFactory;
+    private ItemFactory $itemFactory;
 
     public function __construct(
-        API\Repository $repository,
+        Repository $repository,
         array $fieldInputHandlers,
         NameHelper $nameHelper,
         ItemFactory $relatedContentItemFactory
@@ -56,7 +55,7 @@ class DomainContentMutationResolver
         $this->itemFactory = $relatedContentItemFactory;
     }
 
-    public function updateDomainContent($input, Argument $args, $versionNo, $language): Item
+    public function updateDomainContent($input, Argument $args, $versionNo, ?string $language): Item
     {
         if (isset($args['id'])) {
             $idArray = GlobalId::fromGlobalId($args['id']);
@@ -140,11 +139,11 @@ class DomainContentMutationResolver
         return $this->itemFactory->fromContent($this->getContentService()->loadContent($contentDraft->id));
     }
 
-    public function createDomainContent($input, $contentTypeIdentifier, $parentLocationId, $language): Item
+    public function createDomainContent($input, string $contentTypeIdentifier, $parentLocationId, ?string $language): Item
     {
         try {
             $contentType = $this->getContentTypeService()->loadContentTypeByIdentifier($contentTypeIdentifier);
-        } catch (API\Exceptions\NotFoundException $e) {
+        } catch (RepositoryExceptions\NotFoundException $e) {
             throw new UserError($e->getMessage(), 0, $e);
         }
         $contentCreateStruct = $this->getContentService()->newContentCreateStruct($contentType, $language);
@@ -179,7 +178,7 @@ class DomainContentMutationResolver
         return $this->itemFactory->fromContent($content);
     }
 
-    public function deleteDomainContent(Argument $args)
+    public function deleteDomainContent(Argument $args): array
     {
         $globalId = null;
 
@@ -195,9 +194,9 @@ class DomainContentMutationResolver
 
         try {
             $contentInfo = $this->getContentService()->loadContentInfo($contentId);
-        } catch (API\Exceptions\NotFoundException $e) {
+        } catch (RepositoryExceptions\NotFoundException $e) {
             throw new UserError("Could not find a Content item with ID $contentId");
-        } catch (API\Exceptions\UnauthorizedException $e) {
+        } catch (RepositoryExceptions\UnauthorizedException $e) {
             throw new UserError("You are not authorized to load the Content item with ID $contentId");
         }
         if (!isset($globalId)) {
@@ -209,7 +208,7 @@ class DomainContentMutationResolver
 
         try {
             $this->getContentService()->deleteContent($contentInfo);
-        } catch (API\Exceptions\UnauthorizedException $e) {
+        } catch (RepositoryExceptions\UnauthorizedException $e) {
             throw new UserError("You are not authorized to delete the Content item with ID $contentInfo->id");
         }
 
@@ -250,7 +249,7 @@ class DomainContentMutationResolver
         return $this->makeDomainContentTypeName($contentTypesMap[$contentInfo->contentTypeId]);
     }
 
-    private function makeDomainContentTypeName(RepositoryValues\ContentType\ContentType $contentType)
+    private function makeDomainContentTypeName(RepositoryValues\ContentType\ContentType $contentType): string
     {
         $converter = new CamelCaseToSnakeCaseNameConverter(null, false);
 
@@ -258,32 +257,35 @@ class DomainContentMutationResolver
     }
 
     /**
-     * @return API\ContentService
+     * @return \Ibexa\Contracts\Core\Repository\ContentService
      */
-    private function getContentService()
+    private function getContentService(): ContentService
     {
         return $this->repository->getContentService();
     }
 
     /**
-     * @return API\ContentTypeService
+     * @return \Ibexa\Contracts\Core\Repository\ContentTypeService
      */
-    private function getContentTypeService()
+    private function getContentTypeService(): ContentTypeService
     {
         return $this->repository->getContentTypeService();
     }
 
-    private function getLocationService()
+    private function getLocationService(): LocationService
     {
         return $this->repository->getLocationService();
     }
 
-    private function renderFieldValidationErrors(RepositoryExceptions\ContentFieldValidationException $e, API\Values\ContentType\ContentType $contentType)
+    /**
+     * @return string[]
+     */
+    private function renderFieldValidationErrors(RepositoryExceptions\ContentFieldValidationException $e, RepositoryValues\ContentType\ContentType $contentType): array
     {
         $errors = [];
         foreach ($e->getFieldErrors() as $fieldDefId => $fieldErrorByLanguage) {
             $fieldDefinition = $contentType->getFieldDefinitions()->filter(
-                static function (FieldDefinition $fieldDefinition) use ($fieldDefId) {
+                static function (FieldDefinition $fieldDefinition) use ($fieldDefId): bool {
                     return $fieldDefinition->id === $fieldDefId;
                 }
             )->first();
@@ -310,7 +312,7 @@ class DomainContentMutationResolver
      *
      * @return string
      */
-    private function getInputField(FieldDefinition $fieldDefinition)
+    private function getInputField(FieldDefinition $fieldDefinition): string
     {
         return $this->nameHelper->fieldDefinitionField($fieldDefinition);
     }

--- a/src/lib/Resolver/DomainContentMutationResolver.php
+++ b/src/lib/Resolver/DomainContentMutationResolver.php
@@ -29,9 +29,6 @@ use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter
  */
 class DomainContentMutationResolver
 {
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\Repository
-     */
     private Repository $repository;
 
     /**
@@ -139,7 +136,7 @@ class DomainContentMutationResolver
         return $this->itemFactory->fromContent($this->getContentService()->loadContent($contentDraft->id));
     }
 
-    public function createDomainContent($input, string $contentTypeIdentifier, $parentLocationId, ?string $language): Item
+    public function createDomainContent($input, string $contentTypeIdentifier, $parentLocationId, string $language): Item
     {
         try {
             $contentType = $this->getContentTypeService()->loadContentTypeByIdentifier($contentTypeIdentifier);
@@ -178,6 +175,9 @@ class DomainContentMutationResolver
         return $this->itemFactory->fromContent($content);
     }
 
+    /**
+     * @return array{id: string, contentId: int}
+     */
     public function deleteDomainContent(Argument $args): array
     {
         $globalId = null;

--- a/src/lib/Resolver/DomainContentResolver.php
+++ b/src/lib/Resolver/DomainContentResolver.php
@@ -54,6 +54,7 @@ class DomainContentResolver implements QueryInterface
 
     /**
      * @param string $contentTypeIdentifier
+     *
      * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content[]
      */
     public function resolveDomainContentItems($contentTypeIdentifier, Argument $query): array

--- a/src/lib/Resolver/DomainContentResolver.php
+++ b/src/lib/Resolver/DomainContentResolver.php
@@ -8,6 +8,7 @@
 namespace Ibexa\GraphQL\Resolver;
 
 use GraphQL\Error\UserError;
+use Ibexa\Contracts\Core\Repository\LocationService;
 use Ibexa\Contracts\Core\Repository\Repository;
 use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query;
@@ -27,30 +28,18 @@ use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter
  */
 class DomainContentResolver implements QueryInterface
 {
-    /**
-     * @var \Overblog\GraphQLBundle\Resolver\TypeResolver
-     */
-    private $typeResolver;
+    private TypeResolver $typeResolver;
 
     /**
      * @var SearchQueryMapper
      */
     private $queryMapper;
 
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\Repository
-     */
-    private $repository;
+    private Repository $repository;
 
-    /**
-     * @var \Ibexa\GraphQL\DataLoader\ContentLoader
-     */
-    private $contentLoader;
+    private ContentLoader $contentLoader;
 
-    /**
-     * @var \Ibexa\GraphQL\DataLoader\ContentTypeLoader
-     */
-    private $contentTypeLoader;
+    private ContentTypeLoader $contentTypeLoader;
 
     public function __construct(
         Repository $repository,
@@ -66,7 +55,7 @@ class DomainContentResolver implements QueryInterface
         $this->contentTypeLoader = $contentTypeLoader;
     }
 
-    public function resolveDomainContentItems($contentTypeIdentifier, $query = null)
+    public function resolveDomainContentItems($contentTypeIdentifier, ?Argument $query = null): array
     {
         return $this->findContentItemsByTypeIdentifier($contentTypeIdentifier, $query);
     }
@@ -172,7 +161,7 @@ class DomainContentResolver implements QueryInterface
             : 'UntypedContent';
     }
 
-    private function makeDomainContentTypeName(ContentType $contentType)
+    private function makeDomainContentTypeName(ContentType $contentType): string
     {
         $converter = new CamelCaseToSnakeCaseNameConverter(null, false);
 
@@ -182,7 +171,7 @@ class DomainContentResolver implements QueryInterface
     /**
      * @return \Ibexa\Contracts\Core\Repository\LocationService
      */
-    private function getLocationService()
+    private function getLocationService(): LocationService
     {
         return $this->repository->getLocationService();
     }

--- a/src/lib/Resolver/DomainContentResolver.php
+++ b/src/lib/Resolver/DomainContentResolver.php
@@ -30,10 +30,7 @@ class DomainContentResolver implements QueryInterface
 {
     private TypeResolver $typeResolver;
 
-    /**
-     * @var SearchQueryMapper
-     */
-    private $queryMapper;
+    private QueryMapper $queryMapper;
 
     private Repository $repository;
 
@@ -55,7 +52,11 @@ class DomainContentResolver implements QueryInterface
         $this->contentTypeLoader = $contentTypeLoader;
     }
 
-    public function resolveDomainContentItems($contentTypeIdentifier, ?Argument $query = null): array
+    /**
+     * @param string $contentTypeIdentifier
+     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content[]
+     */
+    public function resolveDomainContentItems($contentTypeIdentifier, Argument $query): array
     {
         return $this->findContentItemsByTypeIdentifier($contentTypeIdentifier, $query);
     }

--- a/src/lib/Resolver/FieldDefinitionResolver.php
+++ b/src/lib/Resolver/FieldDefinitionResolver.php
@@ -28,7 +28,10 @@ class FieldDefinitionResolver
         return $fieldDefinition->getDescription($languageCode);
     }
 
-    public function resolveSelectionFieldDefinitionOptions(array $options)
+    /**
+     * @return array{index: (int|string), label: mixed}[]
+     */
+    public function resolveSelectionFieldDefinitionOptions(array $options): array
     {
         $return = [];
 

--- a/src/lib/Resolver/ImageAssetFieldResolver.php
+++ b/src/lib/Resolver/ImageAssetFieldResolver.php
@@ -16,7 +16,7 @@ use Ibexa\GraphQL\Value\Field;
 class ImageAssetFieldResolver
 {
     /* @var array<\Ibexa\GraphQL\Mapper\ImageAssetMapperStrategyInterface> */
-    private $strategies;
+    private ?array $strategies = null;
 
     /**
      * @param iterable<\Ibexa\GraphQL\Mapper\ImageAssetMapperStrategyInterface> $strategies

--- a/src/lib/Resolver/ImageAssetFieldResolver.php
+++ b/src/lib/Resolver/ImageAssetFieldResolver.php
@@ -7,7 +7,6 @@
 
 namespace Ibexa\GraphQL\Resolver;
 
-use Ibexa\GraphQL\Mapper\ImageAssetMapperStrategyInterface;
 use Ibexa\GraphQL\Value\Field;
 
 /**
@@ -15,7 +14,7 @@ use Ibexa\GraphQL\Value\Field;
  */
 class ImageAssetFieldResolver
 {
-    /** @var iterable<\Ibexa\GraphQL\Mapper\ImageAssetMapperStrategyInterface> $strategies */
+    /** @var iterable<\Ibexa\GraphQL\Mapper\ImageAssetMapperStrategyInterface> */
     private iterable $strategies;
 
     /**

--- a/src/lib/Resolver/ImageAssetFieldResolver.php
+++ b/src/lib/Resolver/ImageAssetFieldResolver.php
@@ -15,19 +15,15 @@ use Ibexa\GraphQL\Value\Field;
  */
 class ImageAssetFieldResolver
 {
-    /* @var array<\Ibexa\GraphQL\Mapper\ImageAssetMapperStrategyInterface> */
-    private ?array $strategies = null;
+    /** @var iterable<\Ibexa\GraphQL\Mapper\ImageAssetMapperStrategyInterface> $strategies */
+    private iterable $strategies;
 
     /**
      * @param iterable<\Ibexa\GraphQL\Mapper\ImageAssetMapperStrategyInterface> $strategies
      */
-    public function __construct(iterable $strategies)
+    public function __construct(iterable $strategies = [])
     {
-        foreach ($strategies as $strategy) {
-            if ($strategy instanceof ImageAssetMapperStrategyInterface) {
-                $this->strategies[] = $strategy;
-            }
-        }
+        $this->strategies = $strategies;
     }
 
     public function resolveDomainImageAssetFieldValue(?Field $field): ?Field

--- a/src/lib/Resolver/ImageFieldResolver.php
+++ b/src/lib/Resolver/ImageFieldResolver.php
@@ -8,6 +8,8 @@
 namespace Ibexa\GraphQL\Resolver;
 
 use Ibexa\Contracts\Core\Repository\ContentService;
+use Ibexa\Contracts\Core\Repository\Values\Content\Content;
+use Ibexa\Contracts\Core\Repository\Values\Content\Field;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
 use Ibexa\Contracts\Core\Variation\VariationHandler;
 use Ibexa\Core\FieldType\Image\Type;
@@ -40,6 +42,9 @@ class ImageFieldResolver
         $this->contentLoader = $contentLoader;
     }
 
+    /**
+     * @param array{identifier: array<string>} $args
+     */
     public function resolveImageVariations(ImageFieldValue $fieldValue, array $args)
     {
         if ($this->fieldType->isEmptyValue($fieldValue)) {
@@ -55,6 +60,9 @@ class ImageFieldResolver
         return $variations;
     }
 
+    /**
+     * @param array{identifier: string} $args
+     */
     public function resolveImageVariation(ImageFieldValue $fieldValue, array $args)
     {
         if ($this->fieldType->isEmptyValue($fieldValue)) {
@@ -68,7 +76,7 @@ class ImageFieldResolver
     }
 
     /**
-     * @return [Content, Field]
+     * @return array{\Ibexa\Contracts\Core\Repository\Values\Content\Content, \Ibexa\Contracts\Core\Repository\Values\Content\Field}
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
@@ -80,7 +88,7 @@ class ImageFieldResolver
         $content = $this->contentLoader->findSingle(new Criterion\ContentId($contentId));
 
         $fieldFound = false;
-        /** @var $field \Ibexa\Contracts\Core\Repository\Values\Content\Field */
+        /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Field $field */
         foreach ($content->getFields() as $field) {
             if ($field->id == $fieldId) {
                 $fieldFound = true;

--- a/src/lib/Resolver/ImageFieldResolver.php
+++ b/src/lib/Resolver/ImageFieldResolver.php
@@ -10,7 +10,7 @@ namespace Ibexa\GraphQL\Resolver;
 use Ibexa\Contracts\Core\Repository\ContentService;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
 use Ibexa\Contracts\Core\Variation\VariationHandler;
-use Ibexa\Core\FieldType;
+use Ibexa\Core\FieldType\Image\Type;
 use Ibexa\Core\FieldType\Image\Value as ImageFieldValue;
 use Ibexa\GraphQL\DataLoader\ContentLoader;
 use Overblog\GraphQLBundle\Error\UserError;
@@ -20,28 +20,16 @@ use Overblog\GraphQLBundle\Error\UserError;
  */
 class ImageFieldResolver
 {
-    /**
-     * @var \Ibexa\Contracts\Core\Variation\VariationHandler
-     */
-    private $variationHandler;
+    private VariationHandler $variationHandler;
 
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\ContentService
-     */
-    private $contentService;
+    private ContentService $contentService;
 
-    /**
-     * @var FieldType\Image\Type
-     */
-    private $fieldType;
+    private Type $fieldType;
 
-    /**
-     * @var \Ibexa\GraphQL\DataLoader\ContentLoader
-     */
-    private $contentLoader;
+    private ContentLoader $contentLoader;
 
     public function __construct(
-        FieldType\Image\Type $imageFieldType,
+        Type $imageFieldType,
         VariationHandler $variationHandler,
         ContentLoader $contentLoader,
         ContentService $contentService
@@ -52,7 +40,7 @@ class ImageFieldResolver
         $this->contentLoader = $contentLoader;
     }
 
-    public function resolveImageVariations(ImageFieldValue $fieldValue, $args)
+    public function resolveImageVariations(ImageFieldValue $fieldValue, array $args)
     {
         if ($this->fieldType->isEmptyValue($fieldValue)) {
             return null;
@@ -67,7 +55,7 @@ class ImageFieldResolver
         return $variations;
     }
 
-    public function resolveImageVariation(ImageFieldValue $fieldValue, $args)
+    public function resolveImageVariation(ImageFieldValue $fieldValue, array $args)
     {
         if ($this->fieldType->isEmptyValue($fieldValue)) {
             return null;

--- a/src/lib/Resolver/ImageFieldResolver.php
+++ b/src/lib/Resolver/ImageFieldResolver.php
@@ -8,7 +8,6 @@
 namespace Ibexa\GraphQL\Resolver;
 
 use Ibexa\Contracts\Core\Repository\ContentService;
-use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\Contracts\Core\Repository\Values\Content\Field;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
 use Ibexa\Contracts\Core\Variation\VariationHandler;

--- a/src/lib/Resolver/ItemResolver.php
+++ b/src/lib/Resolver/ItemResolver.php
@@ -18,6 +18,7 @@ use Ibexa\GraphQL\InputMapper\QueryMapper;
 use Ibexa\GraphQL\ItemFactory;
 use Ibexa\GraphQL\Value\Field;
 use Ibexa\GraphQL\Value\Item;
+use Overblog\GraphQLBundle\Definition\ArgumentInterface;
 use Overblog\GraphQLBundle\Definition\Resolver\QueryInterface;
 use Overblog\GraphQLBundle\Relay\Connection\Output\Connection;
 use Overblog\GraphQLBundle\Relay\Connection\Paginator;
@@ -123,7 +124,7 @@ final class ItemResolver implements QueryInterface
     /**
      * @return \GraphQL\Executor\Promise\Promise|\Overblog\GraphQLBundle\Relay\Connection\Output\Connection<\Ibexa\GraphQL\Value\Item>
      */
-    public function resolveItemsOfTypeAsConnection(string $contentTypeIdentifier, array $args): Connection|Promise
+    public function resolveItemsOfTypeAsConnection(string $contentTypeIdentifier, ArgumentInterface $args): Connection|Promise
     {
         $query = $args['query'] ?: [];
         $query['ContentTypeIdentifier'] = $contentTypeIdentifier;

--- a/src/lib/Resolver/ItemResolver.php
+++ b/src/lib/Resolver/ItemResolver.php
@@ -29,20 +29,15 @@ use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter
  */
 final class ItemResolver implements QueryInterface
 {
-    /** @var \Overblog\GraphQLBundle\Resolver\TypeResolver */
-    private $typeResolver;
+    private TypeResolver $typeResolver;
 
-    /** @var \Ibexa\GraphQL\InputMapper\QueryMapper */
-    private $queryMapper;
+    private QueryMapper $queryMapper;
 
-    /** @var \Ibexa\GraphQL\DataLoader\ContentLoader */
-    private $contentLoader;
+    private ContentLoader $contentLoader;
 
-    /** @var \Ibexa\GraphQL\DataLoader\LocationLoader */
-    private $locationLoader;
+    private LocationLoader $locationLoader;
 
-    /** @var \Ibexa\GraphQL\ItemFactory */
-    private $itemFactory;
+    private ItemFactory $itemFactory;
 
     public function __construct(
         TypeResolver $typeResolver,
@@ -120,7 +115,7 @@ final class ItemResolver implements QueryInterface
         return $item;
     }
 
-    public function resolveItemFieldValue(Item $item, $fieldDefinitionIdentifier, $args = null): ?Field
+    public function resolveItemFieldValue(Item $item, string $fieldDefinitionIdentifier, $args = null): ?Field
     {
         return Field::fromField($item->getContent()->getField($fieldDefinitionIdentifier, $args['language'] ?? null));
     }
@@ -128,14 +123,14 @@ final class ItemResolver implements QueryInterface
     /**
      * @return \GraphQL\Executor\Promise\Promise|\Overblog\GraphQLBundle\Relay\Connection\Output\Connection<\Ibexa\GraphQL\Value\Item>
      */
-    public function resolveItemsOfTypeAsConnection(string $contentTypeIdentifier, $args): Connection|Promise
+    public function resolveItemsOfTypeAsConnection(string $contentTypeIdentifier, array $args): Connection|Promise
     {
         $query = $args['query'] ?: [];
         $query['ContentTypeIdentifier'] = $contentTypeIdentifier;
         $query['sortBy'] = $args['sortBy'];
         $query = $this->queryMapper->mapInputToLocationQuery($query);
 
-        $paginator = new Paginator(function ($offset, $limit) use ($query) {
+        $paginator = new Paginator(function ($offset, $limit) use ($query): array {
             $query->offset = $offset;
             $query->limit = $limit ?? 10;
 

--- a/src/lib/Resolver/LocationGuesser/AllAllowedLocationProvider.php
+++ b/src/lib/Resolver/LocationGuesser/AllAllowedLocationProvider.php
@@ -16,10 +16,7 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Content;
  */
 class AllAllowedLocationProvider implements LocationProvider
 {
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\LocationService
-     */
-    private $locationService;
+    private LocationService $locationService;
 
     public function __construct(LocationService $locationService)
     {

--- a/src/lib/Resolver/LocationGuesser/CurrentSiteLocationProvider.php
+++ b/src/lib/Resolver/LocationGuesser/CurrentSiteLocationProvider.php
@@ -19,15 +19,9 @@ use Ibexa\GraphQL\InputMapper\ContentCollectionFilterBuilder;
  */
 class CurrentSiteLocationProvider implements LocationProvider
 {
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\SearchService
-     */
-    private $searchService;
+    private SearchService $searchService;
 
-    /**
-     * @var \Ibexa\GraphQL\InputMapper\ContentCollectionFilterBuilder
-     */
-    private $filterBuilder;
+    private ContentCollectionFilterBuilder $filterBuilder;
 
     public function __construct(SearchService $searchService, ContentCollectionFilterBuilder $filterBuilder)
     {

--- a/src/lib/Resolver/LocationGuesser/FilterLocationGuesser.php
+++ b/src/lib/Resolver/LocationGuesser/FilterLocationGuesser.php
@@ -18,12 +18,9 @@ class FilterLocationGuesser implements LocationGuesser
     /**
      * @var \Ibexa\GraphQL\Resolver\LocationGuesser\LocationFilter[]
      */
-    private $filters;
+    private array $filters;
 
-    /**
-     * @var \Ibexa\GraphQL\Resolver\LocationGuesser\LocationProvider
-     */
-    private $provider;
+    private LocationProvider $provider;
 
     public function __construct(LocationProvider $provider, array $filters)
     {

--- a/src/lib/Resolver/LocationGuesser/LocationGuess.php
+++ b/src/lib/Resolver/LocationGuesser/LocationGuess.php
@@ -14,15 +14,12 @@ use Ibexa\GraphQL\Exception;
 
 class LocationGuess
 {
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\Values\Content\Content
-     */
-    private $content;
+    private Content $content;
 
     /**
      * @var \Ibexa\Contracts\Core\Repository\Values\Content\Location[]
      */
-    private $locations;
+    private array $locations;
 
     public function __construct(Content $content, array $locations)
     {

--- a/src/lib/Resolver/LocationGuesser/ObjectStorageLocationList.php
+++ b/src/lib/Resolver/LocationGuesser/ObjectStorageLocationList.php
@@ -16,15 +16,10 @@ final class ObjectStorageLocationList implements LocationList
 {
     /**
      * The content item locations were guessed for.
-     *
-     * @var \Ibexa\Contracts\Core\Repository\Values\Content\Content
      */
-    private $content;
+    private Content $content;
 
-    /**
-     * @var \SplObjectStorage
-     */
-    private $locations;
+    private SplObjectStorage $locations;
 
     public function __construct(Content $content)
     {

--- a/src/lib/Resolver/LocationGuesser/TreeRootLocationFilter.php
+++ b/src/lib/Resolver/LocationGuesser/TreeRootLocationFilter.php
@@ -21,20 +21,11 @@ use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
  */
 class TreeRootLocationFilter implements LocationFilter
 {
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\LocationService
-     */
-    private $locationService;
+    private LocationService $locationService;
 
-    /**
-     * @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface
-     */
-    private $configResolver;
+    private ConfigResolverInterface $configResolver;
 
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\URLAliasService
-     */
-    private $urlAliasService;
+    private URLAliasService $urlAliasService;
 
     public function __construct(LocationService $locationService, URLAliasService $urlAliasService, ConfigResolverInterface $configResolver)
     {

--- a/src/lib/Resolver/LocationResolver.php
+++ b/src/lib/Resolver/LocationResolver.php
@@ -60,6 +60,9 @@ class LocationResolver implements QueryInterface
         throw new ArgumentsException('Requires one and only one of remoteId or locationId');
     }
 
+    /**
+     * @return iterable<\Ibexa\Contracts\Core\Repository\Values\Content\Location>
+     */
     public function resolveLocationsByContentId(int $contentId): iterable
     {
         return $this->locationService->loadLocations(

--- a/src/lib/Resolver/LocationResolver.php
+++ b/src/lib/Resolver/LocationResolver.php
@@ -9,8 +9,8 @@ namespace Ibexa\GraphQL\Resolver;
 
 use Ibexa\Contracts\Core\Repository\ContentService;
 use Ibexa\Contracts\Core\Repository\LocationService;
+use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Contracts\Core\Repository\Values\Content\LocationQuery;
-use Ibexa\Contracts\Core\Repository\Values\Content\Query;
 use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
 use Ibexa\GraphQL\DataLoader\Exception\ArgumentsException;
 use Ibexa\GraphQL\DataLoader\LocationLoader;
@@ -27,25 +27,13 @@ class LocationResolver implements QueryInterface
 {
     public const DEFAULT_LIMIT = 10;
 
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\LocationService
-     */
-    private $locationService;
+    private LocationService $locationService;
 
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\ContentService
-     */
-    private $contentService;
+    private ContentService $contentService;
 
-    /**
-     * @var \Ibexa\GraphQL\DataLoader\LocationLoader
-     */
-    private $locationLoader;
+    private LocationLoader $locationLoader;
 
-    /**
-     * @var \Ibexa\GraphQL\InputMapper\SearchQuerySortByMapper
-     */
-    private $sortMapper;
+    private SearchQuerySortByMapper $sortMapper;
 
     public function __construct(
         LocationService $locationService,
@@ -59,7 +47,7 @@ class LocationResolver implements QueryInterface
         $this->sortMapper = $sortMapper;
     }
 
-    public function resolveLocation($args)
+    public function resolveLocation($args): Location
     {
         if (isset($args['locationId'])) {
             return $this->locationLoader->findById($args['locationId']);
@@ -72,14 +60,14 @@ class LocationResolver implements QueryInterface
         throw new ArgumentsException('Requires one and only one of remoteId or locationId');
     }
 
-    public function resolveLocationsByContentId($contentId)
+    public function resolveLocationsByContentId(int $contentId): iterable
     {
         return $this->locationService->loadLocations(
             $this->contentService->loadContentInfo($contentId)
         );
     }
 
-    public function resolveLocationById($locationId)
+    public function resolveLocationById(int $locationId): Location
     {
         return $this->locationService->loadLocation($locationId);
     }
@@ -119,6 +107,6 @@ class LocationResolver implements QueryInterface
 
     private function buildFilter(Argument $args): Criterion
     {
-        return new Query\Criterion\ParentLocationId($args['locationId']);
+        return new Criterion\ParentLocationId($args['locationId']);
     }
 }

--- a/src/lib/Resolver/Map/UploadMap.php
+++ b/src/lib/Resolver/Map/UploadMap.php
@@ -15,7 +15,7 @@ class UploadMap extends ResolverMap
     protected function map()
     {
         return [
-            'FileUpload' => [self::SCALAR_TYPE => static function () { return new GraphQLUploadType(); }],
+            'FileUpload' => [self::SCALAR_TYPE => static function (): GraphQLUploadType { return new GraphQLUploadType(); }],
         ];
     }
 }

--- a/src/lib/Resolver/ObjectStateGroupResolver.php
+++ b/src/lib/Resolver/ObjectStateGroupResolver.php
@@ -18,8 +18,7 @@ use Overblog\GraphQLBundle\Definition\Argument;
  */
 class ObjectStateGroupResolver
 {
-    /** @var \Ibexa\Contracts\Core\Repository\ObjectStateService */
-    private $objectStateService;
+    private ObjectStateService $objectStateService;
 
     public function __construct(ObjectStateService $objectStateService)
     {

--- a/src/lib/Resolver/ObjectStateResolver.php
+++ b/src/lib/Resolver/ObjectStateResolver.php
@@ -20,8 +20,7 @@ use Overblog\GraphQLBundle\Definition\Argument;
  */
 class ObjectStateResolver
 {
-    /** @var \Ibexa\Contracts\Core\Repository\ObjectStateService */
-    private $objectStateService;
+    private ObjectStateService $objectStateService;
 
     public function __construct(ObjectStateService $objectStateService)
     {

--- a/src/lib/Resolver/RelationFieldResolver.php
+++ b/src/lib/Resolver/RelationFieldResolver.php
@@ -17,11 +17,9 @@ use Overblog\GraphQLBundle\Definition\Resolver\QueryInterface;
 
 final class RelationFieldResolver implements QueryInterface
 {
-    /** @var \Ibexa\GraphQL\DataLoader\ContentLoader */
-    private $contentLoader;
+    private ContentLoader $contentLoader;
 
-    /** @var \Ibexa\GraphQL\ItemFactory */
-    private $itemFactory;
+    private ItemFactory $itemFactory;
 
     public function __construct(ContentLoader $contentLoader, ItemFactory $relatedContentItemFactory)
     {

--- a/src/lib/Resolver/RichTextResolver.php
+++ b/src/lib/Resolver/RichTextResolver.php
@@ -8,6 +8,7 @@
 namespace Ibexa\GraphQL\Resolver;
 
 use DOMDocument;
+use Ibexa\Contracts\FieldTypeRichText\RichText\Converter;
 use Ibexa\Contracts\FieldTypeRichText\RichText\Converter as RichTextConverterInterface;
 
 /**
@@ -15,15 +16,9 @@ use Ibexa\Contracts\FieldTypeRichText\RichText\Converter as RichTextConverterInt
  */
 class RichTextResolver
 {
-    /**
-     * @var \Ibexa\Contracts\FieldTypeRichText\RichText\Converter
-     */
-    private $richTextConverter;
+    private Converter $richTextConverter;
 
-    /**
-     * @var \Ibexa\Contracts\FieldTypeRichText\RichText\Converter
-     */
-    private $richTextEditConverter;
+    private Converter $richTextEditConverter;
 
     public function __construct(RichTextConverterInterface $richTextConverter, RichTextConverterInterface $richTextEditConverter)
     {
@@ -31,17 +26,17 @@ class RichTextResolver
         $this->richTextEditConverter = $richTextEditConverter;
     }
 
-    public function xmlToHtml5(DOMDocument $document)
+    public function xmlToHtml5(DOMDocument $document): string|false
     {
         return $this->richTextConverter->convert($document)->saveHTML();
     }
 
-    public function xmlToHtml5Edit(DOMDocument $document)
+    public function xmlToHtml5Edit(DOMDocument $document): string|false
     {
         return $this->richTextEditConverter->convert($document)->saveHTML();
     }
 
-    public function xmlToPlainText(DOMDocument $document)
+    public function xmlToPlainText(DOMDocument $document): string
     {
         $html = $this->richTextConverter->convert($document)->saveHTML();
 

--- a/src/lib/Resolver/SearchResolver.php
+++ b/src/lib/Resolver/SearchResolver.php
@@ -7,8 +7,10 @@
 
 namespace Ibexa\GraphQL\Resolver;
 
+use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\GraphQL\DataLoader\ContentLoader;
 use Ibexa\GraphQL\InputMapper\SearchQueryMapper;
+use Overblog\GraphQLBundle\Definition\ArgumentInterface;
 use Overblog\GraphQLBundle\Relay\Connection\Paginator;
 
 /**
@@ -26,6 +28,23 @@ class SearchResolver
         $this->queryMapper = $queryMapper;
     }
 
+    /**
+     * @param array{
+     *     query: array{
+     *         offset?: int,
+     *         limit?: int,
+     *         ContentTypeIdentifier?: string|string[],
+     *         Text?: string,
+     *         Field?: array<array{target: mixed}>,
+     *         ParentLocationId?: int|int[],
+     *         sortBy?: array<string|\Ibexa\Contracts\Core\Repository\Values\Content\Query::SORT_*>,
+     *         Modified?: array<string, mixed>,
+     *         Created?: array<string, mixed>
+     *     }
+     * } $args
+     *
+     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Content[]
+     */
     public function searchContent(array $args): array
     {
         return $this->contentLoader->find(
@@ -33,7 +52,11 @@ class SearchResolver
         );
     }
 
-    public function searchContentOfTypeAsConnection($contentTypeIdentifier, array $args)
+    /**
+     * @param string $contentTypeIdentifier
+     * @return \GraphQL\Executor\Promise\Promise|\Overblog\GraphQLBundle\Relay\Connection\Output\Connection<\Ibexa\Contracts\Core\Repository\Values\Content\Content>
+     */
+    public function searchContentOfTypeAsConnection($contentTypeIdentifier, ArgumentInterface $args)
     {
         $query = $args['query'] ?: [];
         $query['ContentTypeIdentifier'] = $contentTypeIdentifier;

--- a/src/lib/Resolver/SearchResolver.php
+++ b/src/lib/Resolver/SearchResolver.php
@@ -16,15 +16,9 @@ use Overblog\GraphQLBundle\Relay\Connection\Paginator;
  */
 class SearchResolver
 {
-    /**
-     * @var \Ibexa\GraphQL\InputMapper\SearchQueryMapper
-     */
-    private $queryMapper;
+    private SearchQueryMapper $queryMapper;
 
-    /**
-     * @var \Ibexa\GraphQL\DataLoader\ContentLoader
-     */
-    private $contentLoader;
+    private ContentLoader $contentLoader;
 
     public function __construct(ContentLoader $contentLoader, SearchQueryMapper $queryMapper)
     {
@@ -32,14 +26,14 @@ class SearchResolver
         $this->queryMapper = $queryMapper;
     }
 
-    public function searchContent($args)
+    public function searchContent(array $args): array
     {
         return $this->contentLoader->find(
             $this->queryMapper->mapInputToQuery($args['query'])
         );
     }
 
-    public function searchContentOfTypeAsConnection($contentTypeIdentifier, $args)
+    public function searchContentOfTypeAsConnection($contentTypeIdentifier, array $args)
     {
         $query = $args['query'] ?: [];
         $query['ContentTypeIdentifier'] = $contentTypeIdentifier;

--- a/src/lib/Resolver/SearchResolver.php
+++ b/src/lib/Resolver/SearchResolver.php
@@ -7,7 +7,6 @@
 
 namespace Ibexa\GraphQL\Resolver;
 
-use Ibexa\Contracts\Core\Repository\Values\Content\Content;
 use Ibexa\GraphQL\DataLoader\ContentLoader;
 use Ibexa\GraphQL\InputMapper\SearchQueryMapper;
 use Overblog\GraphQLBundle\Definition\ArgumentInterface;
@@ -54,6 +53,7 @@ class SearchResolver
 
     /**
      * @param string $contentTypeIdentifier
+     *
      * @return \GraphQL\Executor\Promise\Promise|\Overblog\GraphQLBundle\Relay\Connection\Output\Connection<\Ibexa\Contracts\Core\Repository\Values\Content\Content>
      */
     public function searchContentOfTypeAsConnection($contentTypeIdentifier, ArgumentInterface $args)

--- a/src/lib/Resolver/SectionResolver.php
+++ b/src/lib/Resolver/SectionResolver.php
@@ -17,17 +17,14 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Section;
  */
 class SectionResolver
 {
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\SectionService
-     */
-    private $sectionService;
+    private SectionService $sectionService;
 
     public function __construct(SectionService $sectionService)
     {
         $this->sectionService = $sectionService;
     }
 
-    public function resolveSectionById($sectionId): ?Section
+    public function resolveSectionById(int $sectionId): ?Section
     {
         try {
             return $this->sectionService->loadSection($sectionId);

--- a/src/lib/Resolver/SelectionFieldResolver.php
+++ b/src/lib/Resolver/SelectionFieldResolver.php
@@ -17,10 +17,7 @@ use Ibexa\GraphQL\Value\Field;
  */
 class SelectionFieldResolver
 {
-    /**
-     * @var \Ibexa\GraphQL\DataLoader\ContentTypeLoader
-     */
-    private $contentTypeLoader;
+    private ContentTypeLoader $contentTypeLoader;
 
     public function __construct(
         ContentTypeLoader $contentTypeLoader

--- a/src/lib/Resolver/SiteaccessGuesser/SiteaccessGuesser.php
+++ b/src/lib/Resolver/SiteaccessGuesser/SiteaccessGuesser.php
@@ -13,32 +13,21 @@ use Ibexa\Contracts\Core\Repository\Values\Content\Location;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\Core\MVC\Symfony\SiteAccess;
 use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessProviderInterface;
+use Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
 use Ibexa\GraphQL\Exception\NoValidSiteaccessException;
 
 class SiteaccessGuesser
 {
-    /**
-     * @var \Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessProviderInterface
-     */
-    private $provider;
+    private SiteAccessProviderInterface $provider;
 
-    /**
-     * @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface
-     */
-    private $configResolver;
+    private ConfigResolverInterface $configResolver;
 
-    /**
-     * @var \Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface
-     */
-    private $siteAccessService;
+    private SiteAccessServiceInterface $siteAccessService;
 
-    /**
-     * @var array
-     */
-    private $siteAccessGroups;
+    private array $siteAccessGroups;
 
     public function __construct(
-        SiteAccess\SiteAccessServiceInterface $siteAccessService,
+        SiteAccessServiceInterface $siteAccessService,
         SiteAccessProviderInterface $provider,
         ConfigResolverInterface $configResolver,
         array $siteAccessGroups
@@ -99,12 +88,12 @@ class SiteaccessGuesser
      *
      * @return int|false The root depth (used to select the deepest, most specific tree root), false if it isn't part of that subtree.
      */
-    private function isInSubtree(Location $location, int $treeRootLocationId)
+    private function isInSubtree(Location $location, int $treeRootLocationId): int|string|false
     {
         return array_search($treeRootLocationId, $location->path);
     }
 
-    private function isAdminSiteaccess(SiteAccess $siteaccess)
+    private function isAdminSiteaccess(SiteAccess $siteaccess): bool
     {
         return (new IsAdmin($this->siteAccessGroups))->isSatisfiedBy($siteaccess);
     }

--- a/src/lib/Resolver/UrlAliasResolver.php
+++ b/src/lib/Resolver/UrlAliasResolver.php
@@ -23,35 +23,20 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  */
 class UrlAliasResolver
 {
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\URLAliasService
-     */
-    private $urlAliasService;
+    private URLAliasService $urlAliasService;
 
-    /**
-     * @var \Overblog\GraphQLBundle\Resolver\TypeResolver
-     */
-    private $typeResolver;
+    private TypeResolver $typeResolver;
 
-    /**
-     * @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface
-     */
-    private $configResolver;
+    private ConfigResolverInterface $configResolver;
 
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\LocationService
-     */
-    private $locationService;
+    private LocationService $locationService;
 
-    /**
-     * @var \Ibexa\Core\MVC\Symfony\Routing\Generator\UrlAliasGenerator
-     */
-    private $urlGenerator;
+    private UrlAliasGenerator $urlGenerator;
 
     /**
      * @var \Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService
      */
-    private $siteaccessService;
+    private SiteAccessServiceInterface $siteaccessService;
 
     public function __construct(
         TypeResolver $typeResolver,
@@ -69,7 +54,7 @@ class UrlAliasResolver
         $this->siteaccessService = $siteAccessService;
     }
 
-    public function resolveLocationUrlAliases(Location $location, $args)
+    public function resolveLocationUrlAliases(Location $location, $args): iterable
     {
         return $this->urlAliasService->listLocationAliases(
             $location,

--- a/src/lib/Resolver/UrlAliasResolver.php
+++ b/src/lib/Resolver/UrlAliasResolver.php
@@ -54,6 +54,11 @@ class UrlAliasResolver
         $this->siteaccessService = $siteAccessService;
     }
 
+    /**
+     * @param array{custom ?: bool} $args
+     *
+     * @return iterable<\Ibexa\Contracts\Core\Repository\Values\Content\URLAlias>
+     */
     public function resolveLocationUrlAliases(Location $location, $args): iterable
     {
         return $this->urlAliasService->listLocationAliases(

--- a/src/lib/Resolver/UserResolver.php
+++ b/src/lib/Resolver/UserResolver.php
@@ -20,15 +20,9 @@ use Overblog\GraphQLBundle\Error\UserWarning;
  */
 class UserResolver
 {
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\UserService
-     */
-    private $userService;
+    private UserService $userService;
 
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\LocationService
-     */
-    private $locationService;
+    private LocationService $locationService;
 
     public function __construct(UserService $userService, LocationService $locationService)
     {
@@ -51,7 +45,7 @@ class UserResolver
         }
     }
 
-    public function resolveUserById($userId): ?User
+    public function resolveUserById(int $userId): ?User
     {
         try {
             return $this->userService->loadUser($userId);
@@ -63,14 +57,14 @@ class UserResolver
     /**
      * @return \Ibexa\Contracts\Core\Repository\Values\User\UserGroup[]
      */
-    public function resolveUserGroupsByUserId($userId)
+    public function resolveUserGroupsByUserId(int $userId): iterable
     {
         return $this->userService->loadUserGroupsOfUser(
             $this->userService->loadUser($userId)
         );
     }
 
-    public function resolveUsersOfGroup(UserGroup $userGroup)
+    public function resolveUsersOfGroup(UserGroup $userGroup): iterable
     {
         return $this->userService->loadUsersOfUserGroup(
             $userGroup
@@ -80,17 +74,17 @@ class UserResolver
     /**
      * @return \Ibexa\Contracts\Core\Repository\Values\User\UserGroup
      */
-    public function resolveUserGroupById($userGroupId)
+    public function resolveUserGroupById(int $userGroupId): UserGroup
     {
         return $this->userService->loadUserGroup($userGroupId);
     }
 
-    public function resolveUserGroupSubGroups(UserGroup $userGroup)
+    public function resolveUserGroupSubGroups(UserGroup $userGroup): iterable
     {
         return $this->userService->loadSubUserGroups($userGroup);
     }
 
-    public function resolveUserGroups($args)
+    public function resolveUserGroups(array $args): iterable
     {
         return $this->userService->loadSubUserGroups(
             $this->userService->loadUserGroup(
@@ -99,7 +93,7 @@ class UserResolver
         );
     }
 
-    public function resolveContentFields(Content $content, $args)
+    public function resolveContentFields(Content $content, $args): array|iterable
     {
         if (isset($args['identifier'])) {
             return [$content->getField($args['identifier'])];

--- a/src/lib/Resolver/UserResolver.php
+++ b/src/lib/Resolver/UserResolver.php
@@ -30,7 +30,12 @@ class UserResolver
         $this->locationService = $locationService;
     }
 
-    public function resolveUser($args)
+    /**
+     * @param array{id?: int, email?: string, login?: string} $args
+     *
+     * @return \Ibexa\Contracts\Core\Repository\Values\User\User|iterable<\Ibexa\Contracts\Core\Repository\Values\User\User>
+     */
+    public function resolveUser($args): User|iterable
     {
         if (isset($args['id'])) {
             return $this->userService->loadUser($args['id']);
@@ -43,6 +48,8 @@ class UserResolver
         if (isset($args['login'])) {
             return $this->userService->loadUserByLogin($args['login']);
         }
+
+        throw new UserWarning('Missing: id, email or login argument');
     }
 
     public function resolveUserById(int $userId): ?User
@@ -64,6 +71,9 @@ class UserResolver
         );
     }
 
+    /**
+     * @return iterable<\Ibexa\Contracts\Core\Repository\Values\User\User>
+     */
     public function resolveUsersOfGroup(UserGroup $userGroup): iterable
     {
         return $this->userService->loadUsersOfUserGroup(
@@ -79,11 +89,20 @@ class UserResolver
         return $this->userService->loadUserGroup($userGroupId);
     }
 
+    /**
+     * @return iterable<\Ibexa\Contracts\Core\Repository\Values\User\UserGroup>
+     */
     public function resolveUserGroupSubGroups(UserGroup $userGroup): iterable
     {
         return $this->userService->loadSubUserGroups($userGroup);
     }
 
+
+    /**
+     * @param array{id: int} $args
+     *
+     * @return iterable<\Ibexa\Contracts\Core\Repository\Values\User\UserGroup>
+     */
     public function resolveUserGroups(array $args): iterable
     {
         return $this->userService->loadSubUserGroups(
@@ -93,7 +112,12 @@ class UserResolver
         );
     }
 
-    public function resolveContentFields(Content $content, $args): array|iterable
+    /**
+     * @param array{identifier?: string} $args
+     *
+     * @return iterable<\Ibexa\Contracts\Core\Repository\Values\Content\Field|null>
+     */
+    public function resolveContentFields(Content $content, array $args): iterable
     {
         if (isset($args['identifier'])) {
             return [$content->getField($args['identifier'])];

--- a/src/lib/Resolver/UserResolver.php
+++ b/src/lib/Resolver/UserResolver.php
@@ -97,7 +97,6 @@ class UserResolver
         return $this->userService->loadSubUserGroups($userGroup);
     }
 
-
     /**
      * @param array{id: int} $args
      *

--- a/src/lib/Schema/Builder/SchemaBuilder.php
+++ b/src/lib/Schema/Builder/SchemaBuilder.php
@@ -12,6 +12,32 @@ use Ibexa\GraphQL\Schema\Domain\NameValidator;
 
 class SchemaBuilder implements SchemaBuilderInterface
 {
+    /**
+     * @var array<string, array{
+     *     type: string,
+     *     inherits?: array<string>,
+     *     config?: array{
+     *         interfaces?: array<string>,
+     *         nodeType?: mixed,
+     *         connectionFields?: array<string, mixed>,
+     *         fields?: array<string, array{
+     *             type: string,
+     *             description?: string,
+     *             resolve?: callable,
+     *             argsBuilder?: mixed,
+     *             args?: array<string, array{
+     *                 type: string,
+     *                 description?: string,
+     *                 defaultValue?: mixed
+     *             }>
+     *         }>,
+     *         values?: array<string, array{
+     *             value?: mixed,
+     *             description?: string
+     *         }>
+     *     }
+     * }>
+     */
     private array $schema = [];
 
     private NameValidator $nameValidator;

--- a/src/lib/Schema/Builder/SchemaBuilder.php
+++ b/src/lib/Schema/Builder/SchemaBuilder.php
@@ -12,10 +12,9 @@ use Ibexa\GraphQL\Schema\Domain\NameValidator;
 
 class SchemaBuilder implements SchemaBuilderInterface
 {
-    private $schema = [];
+    private array $schema = [];
 
-    /** @var \Ibexa\GraphQL\Schema\Domain\NameValidator */
-    private $nameValidator;
+    private NameValidator $nameValidator;
 
     public function __construct(NameValidator $nameValidator)
     {
@@ -27,7 +26,7 @@ class SchemaBuilder implements SchemaBuilderInterface
         return $this->schema;
     }
 
-    public function addType(Input\Type $typeInput)
+    public function addType(Input\Type $typeInput): void
     {
         if (!$this->nameValidator->isValidName($typeInput->name)) {
             $this->nameValidator->generateInvalidNameWarning($typeInput->type, $typeInput->name);
@@ -62,7 +61,7 @@ class SchemaBuilder implements SchemaBuilderInterface
         $this->schema[$typeInput->name] = $type;
     }
 
-    public function addFieldToType($type, Input\Field $fieldInput)
+    public function addFieldToType($type, Input\Field $fieldInput): void
     {
         if (!$this->nameValidator->isValidName($fieldInput->name)) {
             $this->nameValidator->generateInvalidNameWarning($fieldInput->type, $fieldInput->name);
@@ -92,7 +91,7 @@ class SchemaBuilder implements SchemaBuilderInterface
         $this->schema[$type]['config']['fields'][$fieldInput->name] = $field;
     }
 
-    public function addArgToField($type, $field, Input\Arg $argInput)
+    public function addArgToField($type, $field, Input\Arg $argInput): void
     {
         if (!$this->hasType($type)) {
             throw new \Exception("Expected type $type to be defined, but it was not");
@@ -118,7 +117,7 @@ class SchemaBuilder implements SchemaBuilderInterface
         $this->schema[$type]['config']['fields'][$field]['args'][$argInput->name] = $arg;
     }
 
-    public function addValueToEnum($enum, Input\EnumValue $valueInput)
+    public function addValueToEnum($enum, Input\EnumValue $valueInput): void
     {
         if (!$this->hasType($enum)) {
             throw new \Exception("Expected type $enum to be defined, but it was not");

--- a/src/lib/Schema/Domain/Content/ContentDomainIterator.php
+++ b/src/lib/Schema/Domain/Content/ContentDomainIterator.php
@@ -16,11 +16,9 @@ use Ibexa\GraphQL\Schema\Domain\NameValidator;
 
 class ContentDomainIterator implements Iterator
 {
-    /** @var \Ibexa\Contracts\Core\Repository\ContentTypeService */
-    private $contentTypeService;
+    private ContentTypeService $contentTypeService;
 
-    /** @var \Ibexa\GraphQL\Schema\Domain\NameValidator */
-    private $nameValidator;
+    private NameValidator $nameValidator;
 
     public function __construct(
         ContentTypeService $contentTypeService,
@@ -30,7 +28,7 @@ class ContentDomainIterator implements Iterator
         $this->nameValidator = $nameValidator;
     }
 
-    public function init(Builder $schema)
+    public function init(Builder $schema): void
     {
         $schema->addType(
             new Input\Type('Domain', 'object', ['inherits' => ['Platform']])

--- a/src/lib/Schema/Domain/Content/LanguagesIterator.php
+++ b/src/lib/Schema/Domain/Content/LanguagesIterator.php
@@ -14,10 +14,7 @@ use Ibexa\GraphQL\Schema\Domain\Iterator;
 
 class LanguagesIterator implements Iterator
 {
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\LanguageService
-     */
-    private $languageService;
+    private LanguageService $languageService;
 
     public function __construct(LanguageService $languageService)
     {

--- a/src/lib/Schema/Domain/Content/LanguagesIterator.php
+++ b/src/lib/Schema/Domain/Content/LanguagesIterator.php
@@ -21,7 +21,7 @@ class LanguagesIterator implements Iterator
         $this->languageService = $languageService;
     }
 
-    public function init(Builder $schema)
+    public function init(Builder $schema): void
     {
     }
 

--- a/src/lib/Schema/Domain/Content/Mapper/FieldDefinition/ConfigurableFieldDefinitionMapper.php
+++ b/src/lib/Schema/Domain/Content/Mapper/FieldDefinition/ConfigurableFieldDefinitionMapper.php
@@ -19,10 +19,7 @@ class ConfigurableFieldDefinitionMapper implements FieldDefinitionMapper
      */
     private $typesMap;
 
-    /**
-     * @var \Ibexa\Contracts\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionMapper
-     */
-    private $innerMapper;
+    private FieldDefinitionMapper $innerMapper;
 
     public function __construct(FieldDefinitionMapper $innerMapper, $typesMap = [])
     {

--- a/src/lib/Schema/Domain/Content/Mapper/FieldDefinition/DecoratingFieldDefinitionMapper.php
+++ b/src/lib/Schema/Domain/Content/Mapper/FieldDefinition/DecoratingFieldDefinitionMapper.php
@@ -13,10 +13,7 @@ use Ibexa\Contracts\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDe
 
 abstract class DecoratingFieldDefinitionMapper implements FieldDefinitionMapper
 {
-    /**
-     * @var \Ibexa\Contracts\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionMapper
-     */
-    protected $innerMapper;
+    protected FieldDefinitionMapper $innerMapper;
 
     public function __construct(FieldDefinitionMapper $innerMapper)
     {

--- a/src/lib/Schema/Domain/Content/Mapper/FieldDefinition/RelationFieldDefinitionMapper.php
+++ b/src/lib/Schema/Domain/Content/Mapper/FieldDefinition/RelationFieldDefinitionMapper.php
@@ -15,15 +15,9 @@ use Ibexa\GraphQL\Schema\Domain\Content\NameHelper;
 
 class RelationFieldDefinitionMapper extends DecoratingFieldDefinitionMapper implements FieldDefinitionMapper
 {
-    /**
-     * @var \Ibexa\GraphQL\Schema\Domain\Content\NameHelper
-     */
-    private $nameHelper;
+    private NameHelper $nameHelper;
 
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\ContentTypeService
-     */
-    private $contentTypeService;
+    private ContentTypeService $contentTypeService;
 
     public function __construct(
         FieldDefinitionMapper $innerMapper,
@@ -72,7 +66,7 @@ class RelationFieldDefinitionMapper extends DecoratingFieldDefinitionMapper impl
         return sprintf('@=query("RelationFieldValue", field, %s)', $isMultiple);
     }
 
-    protected function canMap(FieldDefinition $fieldDefinition)
+    protected function canMap(FieldDefinition $fieldDefinition): bool
     {
         return in_array($fieldDefinition->fieldTypeIdentifier, ['ezobjectrelation', 'ezobjectrelationlist']);
     }
@@ -85,7 +79,7 @@ class RelationFieldDefinitionMapper extends DecoratingFieldDefinitionMapper impl
         return '';
     }
 
-    private function isMultiple(FieldDefinition $fieldDefinition)
+    private function isMultiple(FieldDefinition $fieldDefinition): bool
     {
         $constraints = $fieldDefinition->getValidatorConfiguration();
 

--- a/src/lib/Schema/Domain/Content/Mapper/FieldDefinition/ResolverVariables.php
+++ b/src/lib/Schema/Domain/Content/Mapper/FieldDefinition/ResolverVariables.php
@@ -35,7 +35,8 @@ class ResolverVariables implements FieldDefinitionMapper
 
     public function mapToFieldValueResolver(FieldDefinition $fieldDefinition): string
     {
-        $resolver = $this->innerMapper->mapToFieldValueResolver($fieldDefinition);
+        $resolver = $this->innerMapper->mapToFieldValueResolver($fieldDefinition) ?? '';
+
         $resolver = str_replace(
             [
                 'content',

--- a/src/lib/Schema/Domain/Content/Mapper/FieldDefinition/ResolverVariables.php
+++ b/src/lib/Schema/Domain/Content/Mapper/FieldDefinition/ResolverVariables.php
@@ -16,10 +16,7 @@ use Ibexa\Contracts\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDe
  */
 class ResolverVariables implements FieldDefinitionMapper
 {
-    /**
-     * @var \Ibexa\Contracts\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionMapper
-     */
-    private $innerMapper;
+    private FieldDefinitionMapper $innerMapper;
 
     public function __construct(FieldDefinitionMapper $innerMapper)
     {

--- a/src/lib/Schema/Domain/Content/NameHelper.php
+++ b/src/lib/Schema/Domain/Content/NameHelper.php
@@ -38,57 +38,57 @@ class NameHelper extends BaseNameHelper implements LoggerAwareInterface
         $this->fieldNameOverrides = $fieldNameOverrides;
     }
 
-    public function itemConnectionField(ContentType $contentType)
+    public function itemConnectionField(ContentType $contentType): string
     {
         return $this->pluralize(lcfirst($this->toCamelCase($contentType->identifier)));
     }
 
-    public function itemName(ContentType $contentType)
+    public function itemName(ContentType $contentType): string
     {
         return ucfirst($this->toCamelCase($contentType->identifier)) . 'Item';
     }
 
-    public function itemConnectionName($contentType)
+    public function itemConnectionName($contentType): string
     {
         return ucfirst($this->toCamelCase($contentType->identifier)) . 'ItemConnection';
     }
 
-    public function itemCreateInputName(ContentType $contentType)
+    public function itemCreateInputName(ContentType $contentType): string
     {
         return ucfirst($this->toCamelCase($contentType->identifier)) . 'ItemCreateInput';
     }
 
-    public function itemUpdateInputName(ContentType $contentType)
+    public function itemUpdateInputName(ContentType $contentType): string
     {
         return ucfirst($this->toCamelCase($contentType->identifier)) . 'ItemUpdateInput';
     }
 
-    public function itemTypeName(ContentType $contentType)
+    public function itemTypeName(ContentType $contentType): string
     {
         return ucfirst($this->toCamelCase($contentType->identifier)) . 'ItemType';
     }
 
-    public function itemField(ContentType $contentType)
+    public function itemField(ContentType $contentType): string
     {
         return lcfirst($this->toCamelCase($contentType->identifier));
     }
 
-    public function itemMutationCreateItemField(ContentType $contentType)
+    public function itemMutationCreateItemField(ContentType $contentType): string
     {
         return 'create' . ucfirst($this->itemField($contentType));
     }
 
-    public function itemMutationUpdateItemField($contentType)
+    public function itemMutationUpdateItemField(ContentType $contentType): string
     {
         return 'update' . ucfirst($this->itemField($contentType));
     }
 
-    public function itemGroupName(ContentTypeGroup $contentTypeGroup)
+    public function itemGroupName(ContentTypeGroup $contentTypeGroup): string
     {
         return 'ItemGroup' . ucfirst($this->toCamelCase($this->sanitizeContentTypeGroupIdentifier($contentTypeGroup)));
     }
 
-    public function itemGroupTypesName(ContentTypeGroup $contentTypeGroup)
+    public function itemGroupTypesName(ContentTypeGroup $contentTypeGroup): string
     {
         return sprintf(
             'ItemGroup%sTypes',
@@ -98,12 +98,12 @@ class NameHelper extends BaseNameHelper implements LoggerAwareInterface
         );
     }
 
-    public function itemGroupField(ContentTypeGroup $contentTypeGroup)
+    public function itemGroupField(ContentTypeGroup $contentTypeGroup): string
     {
         return lcfirst($this->toCamelCase($this->sanitizeContentTypeGroupIdentifier($contentTypeGroup)));
     }
 
-    public function fieldDefinitionField(FieldDefinition $fieldDefinition)
+    public function fieldDefinitionField(FieldDefinition $fieldDefinition): string
     {
         $fieldName = lcfirst($this->toCamelCase($fieldDefinition->identifier));
 

--- a/src/lib/Schema/Domain/Content/Worker/BaseWorker.php
+++ b/src/lib/Schema/Domain/Content/Worker/BaseWorker.php
@@ -11,12 +11,9 @@ use Ibexa\GraphQL\Schema\Domain\Content\NameHelper;
 
 class BaseWorker
 {
-    /**
-     * @var \Ibexa\GraphQL\Schema\Domain\Content\NameHelper
-     */
-    private $nameHelper;
+    private ?NameHelper $nameHelper = null;
 
-    public function setNameHelper(NameHelper $nameHelper)
+    public function setNameHelper(NameHelper $nameHelper): void
     {
         $this->nameHelper = $nameHelper;
     }

--- a/src/lib/Schema/Domain/Content/Worker/ContentType/AddItemOfTypeConnectionToGroup.php
+++ b/src/lib/Schema/Domain/Content/Worker/ContentType/AddItemOfTypeConnectionToGroup.php
@@ -49,6 +49,7 @@ class AddItemOfTypeConnectionToGroup extends BaseWorker implements Worker
             ['description' => 'A Sort Clause, or array of Clauses. Add _desc after a Clause to reverse it']
         ));
     }
+
     /**
      * @param array{ContentType?: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType|mixed, ContentTypeGroup?: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeGroup|mixed} $args
      */

--- a/src/lib/Schema/Domain/Content/Worker/ContentType/AddItemOfTypeConnectionToGroup.php
+++ b/src/lib/Schema/Domain/Content/Worker/ContentType/AddItemOfTypeConnectionToGroup.php
@@ -16,6 +16,9 @@ use Ibexa\GraphQL\Schema\Worker;
 
 class AddItemOfTypeConnectionToGroup extends BaseWorker implements Worker
 {
+    /**
+     * @param array{ContentType: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType, ContentTypeGroup: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeGroup} $args
+     */
     public function work(Builder $schema, array $args): void
     {
         $contentType = $args['ContentType'];
@@ -46,7 +49,9 @@ class AddItemOfTypeConnectionToGroup extends BaseWorker implements Worker
             ['description' => 'A Sort Clause, or array of Clauses. Add _desc after a Clause to reverse it']
         ));
     }
-
+    /**
+     * @param array{ContentType?: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType|mixed, ContentTypeGroup?: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeGroup|mixed} $args
+     */
     public function canWork(Builder $schema, array $args): bool
     {
         return
@@ -57,21 +62,33 @@ class AddItemOfTypeConnectionToGroup extends BaseWorker implements Worker
             && !$schema->hasTypeWithField($this->groupName($args), $this->connectionField($args));
     }
 
+    /**
+     * @param array{ContentTypeGroup: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeGroup} $args
+     */
     protected function groupName(array $args): string
     {
         return $this->getNameHelper()->itemGroupName($args['ContentTypeGroup']);
     }
 
+    /**
+     * @param array{ContentType: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType} $args
+     */
     protected function connectionField(array $args): string
     {
         return $this->getNameHelper()->itemConnectionField($args['ContentType']);
     }
 
+    /**
+     * @param array{ContentType: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType} $args
+     */
     protected function connectionType(array $args): string
     {
         return $this->getNameHelper()->itemConnectionName($args['ContentType']);
     }
 
+    /**
+     * @param array{ContentType: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType} $args
+     */
     protected function typeName(array $args): string
     {
         return $this->getNameHelper()->itemName($args['ContentType']);

--- a/src/lib/Schema/Domain/Content/Worker/ContentType/AddItemOfTypeConnectionToGroup.php
+++ b/src/lib/Schema/Domain/Content/Worker/ContentType/AddItemOfTypeConnectionToGroup.php
@@ -16,7 +16,7 @@ use Ibexa\GraphQL\Schema\Worker;
 
 class AddItemOfTypeConnectionToGroup extends BaseWorker implements Worker
 {
-    public function work(Builder $schema, array $args)
+    public function work(Builder $schema, array $args): void
     {
         $contentType = $args['ContentType'];
         $descriptions = $contentType->getDescriptions();
@@ -47,7 +47,7 @@ class AddItemOfTypeConnectionToGroup extends BaseWorker implements Worker
         ));
     }
 
-    public function canWork(Builder $schema, array $args)
+    public function canWork(Builder $schema, array $args): bool
     {
         return
             isset($args['ContentType'])
@@ -72,7 +72,7 @@ class AddItemOfTypeConnectionToGroup extends BaseWorker implements Worker
         return $this->getNameHelper()->itemConnectionName($args['ContentType']);
     }
 
-    protected function typeName($args): string
+    protected function typeName(array $args): string
     {
         return $this->getNameHelper()->itemName($args['ContentType']);
     }

--- a/src/lib/Schema/Domain/Content/Worker/ContentType/AddItemToGroup.php
+++ b/src/lib/Schema/Domain/Content/Worker/ContentType/AddItemToGroup.php
@@ -16,6 +16,9 @@ use Ibexa\GraphQL\Schema\Worker;
 
 class AddItemToGroup extends BaseWorker implements Worker
 {
+    /**
+     * @param array{ContentType: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType, ContentTypeGroup: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeGroup} $args
+     */
     public function work(Builder $schema, array $args): void
     {
         $contentType = $args['ContentType'];
@@ -61,6 +64,9 @@ class AddItemToGroup extends BaseWorker implements Worker
         ));
     }
 
+    /**
+     * @param array{ContentType?: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType|mixed, ContentTypeGroup?: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeGroup|mixed} $args
+     */
     public function canWork(Builder $schema, array $args): bool
     {
         return
@@ -71,16 +77,25 @@ class AddItemToGroup extends BaseWorker implements Worker
             && !$schema->hasTypeWithField($this->groupName($args), $this->typeField($args));
     }
 
+    /**
+     * @param array{ContentTypeGroup: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeGroup} $args
+     */
     protected function groupName(array $args): string
     {
         return $this->getNameHelper()->itemGroupName($args['ContentTypeGroup']);
     }
 
+    /**
+     * @param array{ContentType: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType} $args
+     */
     protected function typeField(array $args): string
     {
         return $this->getNameHelper()->itemField($args['ContentType']);
     }
 
+    /**
+     * @param array{ContentType: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType} $args
+     */
     protected function typeName(array $args): string
     {
         return $this->getNameHelper()->itemName($args['ContentType']);

--- a/src/lib/Schema/Domain/Content/Worker/ContentType/AddItemToGroup.php
+++ b/src/lib/Schema/Domain/Content/Worker/ContentType/AddItemToGroup.php
@@ -16,7 +16,7 @@ use Ibexa\GraphQL\Schema\Worker;
 
 class AddItemToGroup extends BaseWorker implements Worker
 {
-    public function work(Builder $schema, array $args)
+    public function work(Builder $schema, array $args): void
     {
         $contentType = $args['ContentType'];
         $descriptions = $contentType->getDescriptions();
@@ -61,7 +61,7 @@ class AddItemToGroup extends BaseWorker implements Worker
         ));
     }
 
-    public function canWork(Builder $schema, array $args)
+    public function canWork(Builder $schema, array $args): bool
     {
         return
             isset($args['ContentType'])
@@ -76,12 +76,12 @@ class AddItemToGroup extends BaseWorker implements Worker
         return $this->getNameHelper()->itemGroupName($args['ContentTypeGroup']);
     }
 
-    protected function typeField($args): string
+    protected function typeField(array $args): string
     {
         return $this->getNameHelper()->itemField($args['ContentType']);
     }
 
-    protected function typeName($args): string
+    protected function typeName(array $args): string
     {
         return $this->getNameHelper()->itemName($args['ContentType']);
     }

--- a/src/lib/Schema/Domain/Content/Worker/ContentType/AddItemTypeToItemGroupTypes.php
+++ b/src/lib/Schema/Domain/Content/Worker/ContentType/AddItemTypeToItemGroupTypes.php
@@ -16,7 +16,7 @@ use Ibexa\GraphQL\Schema\Worker;
 
 class AddItemTypeToItemGroupTypes extends BaseWorker implements Worker
 {
-    public function work(Builder $schema, array $args)
+    public function work(Builder $schema, array $args): void
     {
         $resolve = sprintf(
             '@=query("ContentType", {"identifier": "%s"})',
@@ -33,7 +33,7 @@ class AddItemTypeToItemGroupTypes extends BaseWorker implements Worker
         );
     }
 
-    public function canWork(Builder $schema, array $args)
+    public function canWork(Builder $schema, array $args): bool
     {
         return
             isset($args['ContentType'])

--- a/src/lib/Schema/Domain/Content/Worker/ContentType/AddItemTypeToItemTypeIdentifierList.php
+++ b/src/lib/Schema/Domain/Content/Worker/ContentType/AddItemTypeToItemTypeIdentifierList.php
@@ -21,7 +21,7 @@ class AddItemTypeToItemTypeIdentifierList extends BaseWorker implements Worker, 
 {
     public const TYPE = 'ContentTypeIdentifier';
 
-    public function work(Builder $schema, array $args)
+    public function work(Builder $schema, array $args): void
     {
         $contentType = $args['ContentType'];
 
@@ -37,7 +37,7 @@ class AddItemTypeToItemTypeIdentifierList extends BaseWorker implements Worker, 
         );
     }
 
-    public function init(Builder $schema)
+    public function init(Builder $schema): void
     {
         $schema->addType(new Input\Type(self::TYPE, 'enum'));
     }

--- a/src/lib/Schema/Domain/Content/Worker/ContentType/DefineItem.php
+++ b/src/lib/Schema/Domain/Content/Worker/ContentType/DefineItem.php
@@ -15,7 +15,7 @@ use Ibexa\GraphQL\Schema\Worker;
 
 class DefineItem extends BaseWorker implements Worker
 {
-    public function work(Builder $schema, array $args)
+    public function work(Builder $schema, array $args): void
     {
         $schema->addType(new Input\Type(
             $this->typeName($args),
@@ -27,7 +27,7 @@ class DefineItem extends BaseWorker implements Worker
         ));
     }
 
-    public function canWork(Builder $schema, array $args)
+    public function canWork(Builder $schema, array $args): bool
     {
         return
             isset($args['ContentType'])

--- a/src/lib/Schema/Domain/Content/Worker/ContentType/DefineItemConnection.php
+++ b/src/lib/Schema/Domain/Content/Worker/ContentType/DefineItemConnection.php
@@ -15,7 +15,7 @@ use Ibexa\GraphQL\Schema\Worker;
 
 class DefineItemConnection extends BaseWorker implements Worker
 {
-    public function work(Builder $schema, array $args)
+    public function work(Builder $schema, array $args): void
     {
         $schema->addType(new Input\Type(
             $this->connectionTypeName($args),
@@ -30,7 +30,7 @@ class DefineItemConnection extends BaseWorker implements Worker
         ));
     }
 
-    public function canWork(Builder $schema, array $args)
+    public function canWork(Builder $schema, array $args): bool
     {
         return isset($args['ContentType']) && $args['ContentType'] instanceof ContentType
                && !$schema->hasType($this->connectionTypeName($args));
@@ -41,7 +41,7 @@ class DefineItemConnection extends BaseWorker implements Worker
         return $this->getNameHelper()->itemConnectionName($args['ContentType']);
     }
 
-    protected function typeName($args): string
+    protected function typeName(array $args): string
     {
         return $this->getNameHelper()->itemName($args['ContentType']);
     }

--- a/src/lib/Schema/Domain/Content/Worker/ContentType/DefineItemConnection.php
+++ b/src/lib/Schema/Domain/Content/Worker/ContentType/DefineItemConnection.php
@@ -15,6 +15,9 @@ use Ibexa\GraphQL\Schema\Worker;
 
 class DefineItemConnection extends BaseWorker implements Worker
 {
+    /**
+     * @param array{ContentType: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType} $args
+     */
     public function work(Builder $schema, array $args): void
     {
         $schema->addType(new Input\Type(
@@ -30,17 +33,26 @@ class DefineItemConnection extends BaseWorker implements Worker
         ));
     }
 
+    /**
+     * @param array{ContentType?: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType|mixed} $args
+     */
     public function canWork(Builder $schema, array $args): bool
     {
         return isset($args['ContentType']) && $args['ContentType'] instanceof ContentType
                && !$schema->hasType($this->connectionTypeName($args));
     }
 
+    /**
+     * @param array{ContentType: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType} $args
+     */
     protected function connectionTypeName(array $args): string
     {
         return $this->getNameHelper()->itemConnectionName($args['ContentType']);
     }
 
+    /**
+     * @param array{ContentType: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType} $args
+     */
     protected function typeName(array $args): string
     {
         return $this->getNameHelper()->itemName($args['ContentType']);

--- a/src/lib/Schema/Domain/Content/Worker/ContentType/DefineItemMutation.php
+++ b/src/lib/Schema/Domain/Content/Worker/ContentType/DefineItemMutation.php
@@ -17,7 +17,7 @@ class DefineItemMutation extends BaseWorker implements Worker, Initializer
 {
     public const MUTATION_TYPE = 'ItemMutation';
 
-    public function init(Builder $schema)
+    public function init(Builder $schema): void
     {
         $schema->addType(new Builder\Input\Type(
             self::MUTATION_TYPE,
@@ -26,7 +26,7 @@ class DefineItemMutation extends BaseWorker implements Worker, Initializer
         ));
     }
 
-    public function work(Builder $schema, array $args)
+    public function work(Builder $schema, array $args): void
     {
         $contentType = $args['ContentType'];
 
@@ -107,7 +107,7 @@ class DefineItemMutation extends BaseWorker implements Worker, Initializer
         $schema->addType(new Builder\Input\Type($this->getUpdateInputName($contentType), 'input-object'));
     }
 
-    public function canWork(Builder $schema, array $args)
+    public function canWork(Builder $schema, array $args): bool
     {
         return isset($args['ContentType'])
                && $args['ContentType'] instanceof ContentType

--- a/src/lib/Schema/Domain/Content/Worker/ContentType/DefineItemType.php
+++ b/src/lib/Schema/Domain/Content/Worker/ContentType/DefineItemType.php
@@ -15,7 +15,7 @@ use Ibexa\GraphQL\Schema\Worker;
 
 class DefineItemType extends BaseWorker implements Worker
 {
-    public function work(Builder $schema, array $args)
+    public function work(Builder $schema, array $args): void
     {
         $schema->addType(new Input\Type(
             $this->typeName($args),
@@ -27,7 +27,7 @@ class DefineItemType extends BaseWorker implements Worker
         ));
     }
 
-    public function canWork(Builder $schema, array $args)
+    public function canWork(Builder $schema, array $args): bool
     {
         return
             isset($args['ContentType'])

--- a/src/lib/Schema/Domain/Content/Worker/ContentTypeGroup/AddDomainGroupToDomain.php
+++ b/src/lib/Schema/Domain/Content/Worker/ContentTypeGroup/AddDomainGroupToDomain.php
@@ -16,17 +16,14 @@ use Ibexa\GraphQL\Schema\Worker;
 
 final class AddDomainGroupToDomain extends BaseWorker implements Worker
 {
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\ContentTypeService
-     */
-    private $contentTypeService;
+    private ContentTypeService $contentTypeService;
 
     public function __construct(ContentTypeService $contentTypeService)
     {
         $this->contentTypeService = $contentTypeService;
     }
 
-    public function work(Builder $schema, array $args)
+    public function work(Builder $schema, array $args): void
     {
         $contentTypeGroup = $args['ContentTypeGroup'];
         $schema->addFieldToType('Domain', new Input\Field(
@@ -42,7 +39,7 @@ final class AddDomainGroupToDomain extends BaseWorker implements Worker
         ));
     }
 
-    public function canWork(Builder $schema, array $args)
+    public function canWork(Builder $schema, array $args): bool
     {
         return
             isset($args['ContentTypeGroup'])
@@ -51,12 +48,12 @@ final class AddDomainGroupToDomain extends BaseWorker implements Worker
             && !empty($this->contentTypeService->loadContentTypes($args['ContentTypeGroup']));
     }
 
-    private function fieldName($args): string
+    private function fieldName(array $args): string
     {
         return $this->getNameHelper()->itemGroupField($args['ContentTypeGroup']);
     }
 
-    private function typeGroupName($args): string
+    private function typeGroupName(array $args): string
     {
         return $this->getNameHelper()->itemGroupName($args['ContentTypeGroup']);
     }

--- a/src/lib/Schema/Domain/Content/Worker/ContentTypeGroup/AddDomainGroupToDomain.php
+++ b/src/lib/Schema/Domain/Content/Worker/ContentTypeGroup/AddDomainGroupToDomain.php
@@ -23,6 +23,9 @@ final class AddDomainGroupToDomain extends BaseWorker implements Worker
         $this->contentTypeService = $contentTypeService;
     }
 
+    /**
+     * @param array{ContentTypeGroup: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeGroup} $args
+     */
     public function work(Builder $schema, array $args): void
     {
         $contentTypeGroup = $args['ContentTypeGroup'];
@@ -39,6 +42,9 @@ final class AddDomainGroupToDomain extends BaseWorker implements Worker
         ));
     }
 
+    /**
+     * @param array{ContentTypeGroup?: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeGroup|mixed} $args
+     */
     public function canWork(Builder $schema, array $args): bool
     {
         return
@@ -48,11 +54,17 @@ final class AddDomainGroupToDomain extends BaseWorker implements Worker
             && !empty($this->contentTypeService->loadContentTypes($args['ContentTypeGroup']));
     }
 
+    /**
+     * @param array{ContentTypeGroup: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeGroup} $args
+     */
     private function fieldName(array $args): string
     {
         return $this->getNameHelper()->itemGroupField($args['ContentTypeGroup']);
     }
 
+    /**
+     * @param array{ContentTypeGroup: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeGroup} $args
+     */
     private function typeGroupName(array $args): string
     {
         return $this->getNameHelper()->itemGroupName($args['ContentTypeGroup']);

--- a/src/lib/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroup.php
+++ b/src/lib/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroup.php
@@ -16,17 +16,14 @@ use Ibexa\GraphQL\Schema\Worker;
 
 class DefineDomainGroup extends BaseWorker implements Worker
 {
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\ContentTypeService
-     */
-    private $contentTypeService;
+    private ContentTypeService $contentTypeService;
 
     public function __construct(ContentTypeService $contentTypeService)
     {
         $this->contentTypeService = $contentTypeService;
     }
 
-    public function work(Builder $schema, array $args)
+    public function work(Builder $schema, array $args): void
     {
         $schema->addType(new Input\Type(
             $this->typeName($args),
@@ -44,7 +41,7 @@ class DefineDomainGroup extends BaseWorker implements Worker
         );
     }
 
-    public function canWork(Builder $schema, array $args)
+    public function canWork(Builder $schema, array $args): bool
     {
         return
             isset($args['ContentTypeGroup'])
@@ -53,7 +50,7 @@ class DefineDomainGroup extends BaseWorker implements Worker
             && !empty($this->contentTypeService->loadContentTypes($args['ContentTypeGroup']));
     }
 
-    protected function typeName($args): string
+    protected function typeName(array $args): string
     {
         return $this->getNameHelper()->itemGroupName($args['ContentTypeGroup']);
     }

--- a/src/lib/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroup.php
+++ b/src/lib/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroup.php
@@ -23,6 +23,9 @@ class DefineDomainGroup extends BaseWorker implements Worker
         $this->contentTypeService = $contentTypeService;
     }
 
+    /**
+     * @param array{ContentTypeGroup: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeGroup} $args
+     */
     public function work(Builder $schema, array $args): void
     {
         $schema->addType(new Input\Type(
@@ -41,6 +44,9 @@ class DefineDomainGroup extends BaseWorker implements Worker
         );
     }
 
+    /**
+     * @param array{ContentTypeGroup?: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeGroup|mixed} $args
+     */
     public function canWork(Builder $schema, array $args): bool
     {
         return
@@ -50,11 +56,17 @@ class DefineDomainGroup extends BaseWorker implements Worker
             && !empty($this->contentTypeService->loadContentTypes($args['ContentTypeGroup']));
     }
 
+    /**
+     * @param array{ContentTypeGroup: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeGroup} $args
+     */
     protected function typeName(array $args): string
     {
         return $this->getNameHelper()->itemGroupName($args['ContentTypeGroup']);
     }
 
+    /**
+     * @param array{ContentTypeGroup: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeGroup} $args
+     */
     private function groupTypesName(array $args): string
     {
         return $this->getNameHelper()->itemGroupTypesName($args['ContentTypeGroup']);

--- a/src/lib/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroupTypes.php
+++ b/src/lib/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroupTypes.php
@@ -19,22 +19,19 @@ use Ibexa\GraphQL\Schema\Worker;
  */
 class DefineDomainGroupTypes extends BaseWorker implements Worker
 {
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\ContentTypeService
-     */
-    private $contentTypeService;
+    private ContentTypeService $contentTypeService;
 
     public function __construct(ContentTypeService $contentTypeService)
     {
         $this->contentTypeService = $contentTypeService;
     }
 
-    public function work(Builder $schema, array $args)
+    public function work(Builder $schema, array $args): void
     {
         $schema->addType(new Builder\Input\Type($this->typeName($args), 'object'));
     }
 
-    public function canWork(Builder $schema, array $args)
+    public function canWork(Builder $schema, array $args): bool
     {
         return
             isset($args['ContentTypeGroup'])
@@ -43,7 +40,7 @@ class DefineDomainGroupTypes extends BaseWorker implements Worker
             && !empty($this->contentTypeService->loadContentTypes($args['ContentTypeGroup']));
     }
 
-    private function typeName($args): string
+    private function typeName(array $args): string
     {
         return $this->getNameHelper()->itemGroupTypesName($args['ContentTypeGroup']);
     }

--- a/src/lib/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroupTypes.php
+++ b/src/lib/Schema/Domain/Content/Worker/ContentTypeGroup/DefineDomainGroupTypes.php
@@ -26,11 +26,17 @@ class DefineDomainGroupTypes extends BaseWorker implements Worker
         $this->contentTypeService = $contentTypeService;
     }
 
+    /**
+     * @param array{ContentTypeGroup: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeGroup} $args
+     */
     public function work(Builder $schema, array $args): void
     {
         $schema->addType(new Builder\Input\Type($this->typeName($args), 'object'));
     }
 
+    /**
+     * @param array{ContentTypeGroup?: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeGroup|mixed} $args
+     */
     public function canWork(Builder $schema, array $args): bool
     {
         return
@@ -40,6 +46,9 @@ class DefineDomainGroupTypes extends BaseWorker implements Worker
             && !empty($this->contentTypeService->loadContentTypes($args['ContentTypeGroup']));
     }
 
+    /**
+     * @param array{ContentTypeGroup: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeGroup} $args
+     */
     private function typeName(array $args): string
     {
         return $this->getNameHelper()->itemGroupTypesName($args['ContentTypeGroup']);

--- a/src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToItemMutation.php
+++ b/src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToItemMutation.php
@@ -19,10 +19,7 @@ class AddFieldDefinitionToItemMutation extends BaseWorker implements Worker
     public const OPERATION_CREATE = 'create';
     public const OPERATION_UPDATE = 'update';
 
-    /**
-     * @var \Ibexa\Contracts\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionMapper
-     */
-    private $mapper;
+    private FieldDefinitionMapper $mapper;
 
     /**
      * @param \Ibexa\Contracts\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionMapper $mapper
@@ -32,7 +29,7 @@ class AddFieldDefinitionToItemMutation extends BaseWorker implements Worker
         $this->mapper = $mapper;
     }
 
-    public function work(Builder $schema, array $args)
+    public function work(Builder $schema, array $args): void
     {
         $properties = ['description' => $this->mapDescription($args)];
 
@@ -80,7 +77,7 @@ class AddFieldDefinitionToItemMutation extends BaseWorker implements Worker
         return $this->getNameHelper()->fieldDefinitionField($args['FieldDefinition']);
     }
 
-    private function nameFieldType(array $args, $operation): string
+    private function nameFieldType(array $args, string $operation): string
     {
         $fieldDefinition = $args['FieldDefinition'];
         $contentType = $args['ContentType'];
@@ -96,7 +93,7 @@ class AddFieldDefinitionToItemMutation extends BaseWorker implements Worker
      *
      * @param array $args
      */
-    private function mapDescription($args): ?string
+    private function mapDescription(array $args): ?string
     {
         return $args['FieldDefinition']->getDescription($args['ContentType']->mainLanguageCode);
     }

--- a/src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToItemType.php
+++ b/src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToItemType.php
@@ -9,7 +9,6 @@ namespace Ibexa\GraphQL\Schema\Domain\Content\Worker\FieldDefinition;
 
 use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
 use Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition;
-use Ibexa\Contracts\Core\Repository\Values\MultiLanguageDescription;
 use Ibexa\Contracts\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionMapper;
 use Ibexa\GraphQL\Schema\Builder;
 use Ibexa\GraphQL\Schema\Builder\Input;

--- a/src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToItemType.php
+++ b/src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToItemType.php
@@ -18,17 +18,14 @@ use Ibexa\GraphQL\Schema\Worker;
 
 class AddFieldDefinitionToItemType extends BaseWorker implements Worker
 {
-    /**
-     * @var \Ibexa\Contracts\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionMapper
-     */
-    private $fieldDefinitionMapper;
+    private FieldDefinitionMapper $fieldDefinitionMapper;
 
     public function __construct(FieldDefinitionMapper $fieldDefinitionMapper)
     {
         $this->fieldDefinitionMapper = $fieldDefinitionMapper;
     }
 
-    public function work(Builder $schema, array $args)
+    public function work(Builder $schema, array $args): void
     {
         $schema->addFieldToType($this->typeName($args), new Input\Field(
             $this->fieldName($args),
@@ -43,7 +40,7 @@ class AddFieldDefinitionToItemType extends BaseWorker implements Worker
         ));
     }
 
-    public function canWork(Builder $schema, array $args)
+    public function canWork(Builder $schema, array $args): bool
     {
         return
             isset($args['FieldDefinition'])
@@ -58,12 +55,12 @@ class AddFieldDefinitionToItemType extends BaseWorker implements Worker
         return $this->getNameHelper()->itemTypeName($args['ContentType']);
     }
 
-    protected function fieldName($args): string
+    protected function fieldName(array $args): string
     {
         return $this->getNameHelper()->fieldDefinitionField($args['FieldDefinition']);
     }
 
-    public function fieldDescription($args)
+    public function fieldDescription(array $args)
     {
         $description = '';
         if ($args['FieldDefinition'] instanceof MultiLanguageDescription) {
@@ -73,7 +70,7 @@ class AddFieldDefinitionToItemType extends BaseWorker implements Worker
         return $description;
     }
 
-    private function fieldType($args)
+    private function fieldType(array $args): ?string
     {
         return $this->fieldDefinitionMapper->mapToFieldDefinitionType($args['FieldDefinition']);
     }

--- a/src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToItemType.php
+++ b/src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldDefinitionToItemType.php
@@ -25,6 +25,9 @@ class AddFieldDefinitionToItemType extends BaseWorker implements Worker
         $this->fieldDefinitionMapper = $fieldDefinitionMapper;
     }
 
+    /**
+     * @param array{FieldDefinition: \Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition, ContentType: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType} $args
+     */
     public function work(Builder $schema, array $args): void
     {
         $schema->addFieldToType($this->typeName($args), new Input\Field(
@@ -40,36 +43,46 @@ class AddFieldDefinitionToItemType extends BaseWorker implements Worker
         ));
     }
 
+    /**
+     * @param array{FieldDefinition?: \Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition|mixed, ContentType?: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType|mixed} $args
+     */
     public function canWork(Builder $schema, array $args): bool
     {
         return
             isset($args['FieldDefinition'])
             && $args['FieldDefinition'] instanceof FieldDefinition
-            & isset($args['ContentType'])
+            && isset($args['ContentType'])
             && $args['ContentType'] instanceof ContentType
             && !$schema->hasTypeWithField($this->typeName($args), $this->fieldName($args));
     }
 
+    /**
+     * @param array{ContentType: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType} $args
+     */
     protected function typeName(array $args): string
     {
         return $this->getNameHelper()->itemTypeName($args['ContentType']);
     }
 
+    /**
+     * @param array{FieldDefinition: \Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition} $args
+     */
     protected function fieldName(array $args): string
     {
         return $this->getNameHelper()->fieldDefinitionField($args['FieldDefinition']);
     }
 
+    /**
+     * @param array{FieldDefinition: \Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition} $args
+     */
     public function fieldDescription(array $args)
     {
-        $description = '';
-        if ($args['FieldDefinition'] instanceof MultiLanguageDescription) {
-            $description = $args['FieldDefinition']->getDescription('eng-GB') ?? '';
-        }
-
-        return $description;
+        return $args['FieldDefinition']->getDescription('eng-GB') ?? '';
     }
 
+    /**
+     * @param array{FieldDefinition: \Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition} $args
+     */
     private function fieldType(array $args): ?string
     {
         return $this->fieldDefinitionMapper->mapToFieldDefinitionType($args['FieldDefinition']);

--- a/src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldValueToItem.php
+++ b/src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldValueToItem.php
@@ -17,17 +17,14 @@ use Ibexa\GraphQL\Schema\Worker;
 
 class AddFieldValueToItem extends BaseWorker implements Worker
 {
-    /**
-     * @var \Ibexa\Contracts\GraphQL\Schema\Domain\Content\Mapper\FieldDefinition\FieldDefinitionMapper
-     */
-    private $fieldDefinitionMapper;
+    private FieldDefinitionMapper $fieldDefinitionMapper;
 
     public function __construct(FieldDefinitionMapper $fieldDefinitionMapper)
     {
         $this->fieldDefinitionMapper = $fieldDefinitionMapper;
     }
 
-    public function work(Builder $schema, array $args)
+    public function work(Builder $schema, array $args): void
     {
         $definition = $this->getDefinition($args['FieldDefinition']);
         $schema->addFieldToType(
@@ -44,7 +41,7 @@ class AddFieldValueToItem extends BaseWorker implements Worker
         }
     }
 
-    private function getDefinition(FieldDefinition $fieldDefinition)
+    private function getDefinition(FieldDefinition $fieldDefinition): array
     {
         $definition = [
             'type' => $this->fieldDefinitionMapper->mapToFieldValueType($fieldDefinition),
@@ -58,7 +55,7 @@ class AddFieldValueToItem extends BaseWorker implements Worker
         return $definition;
     }
 
-    public function canWork(Builder $schema, array $args)
+    public function canWork(Builder $schema, array $args): bool
     {
         return
             isset($args['FieldDefinition'])
@@ -73,7 +70,7 @@ class AddFieldValueToItem extends BaseWorker implements Worker
         return $this->getNameHelper()->itemName($args['ContentType']);
     }
 
-    protected function fieldName($args): string
+    protected function fieldName(array $args): string
     {
         return $this->getNameHelper()->fieldDefinitionField($args['FieldDefinition']);
     }

--- a/src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldValueToItem.php
+++ b/src/lib/Schema/Domain/Content/Worker/FieldDefinition/AddFieldValueToItem.php
@@ -24,6 +24,9 @@ class AddFieldValueToItem extends BaseWorker implements Worker
         $this->fieldDefinitionMapper = $fieldDefinitionMapper;
     }
 
+    /**
+     * @param array{FieldDefinition: \Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition, ContentType: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType} $args
+     */
     public function work(Builder $schema, array $args): void
     {
         $definition = $this->getDefinition($args['FieldDefinition']);
@@ -41,6 +44,9 @@ class AddFieldValueToItem extends BaseWorker implements Worker
         }
     }
 
+    /**
+     * @return array{type: string|null, resolve: string|null, argsBuilder?: string|null}
+     */
     private function getDefinition(FieldDefinition $fieldDefinition): array
     {
         $definition = [
@@ -55,21 +61,30 @@ class AddFieldValueToItem extends BaseWorker implements Worker
         return $definition;
     }
 
+    /**
+     * @param array{FieldDefinition?: \Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition|mixed, ContentType?: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType|mixed} $args
+     */
     public function canWork(Builder $schema, array $args): bool
     {
         return
             isset($args['FieldDefinition'])
             && $args['FieldDefinition'] instanceof FieldDefinition
-            & isset($args['ContentType'])
+            && isset($args['ContentType'])
             && $args['ContentType'] instanceof ContentType
             && !$schema->hasTypeWithField($this->typeName($args), $this->fieldName($args));
     }
 
+    /**
+     * @param array{ContentType: \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType} $args
+     */
     protected function typeName(array $args): string
     {
         return $this->getNameHelper()->itemName($args['ContentType']);
     }
 
+    /**
+     * @param array{FieldDefinition: \Ibexa\Contracts\Core\Repository\Values\ContentType\FieldDefinition} $args
+     */
     protected function fieldName(array $args): string
     {
         return $this->getNameHelper()->fieldDefinitionField($args['FieldDefinition']);

--- a/src/lib/Schema/Domain/Content/Worker/Language/AddLanguageToEnum.php
+++ b/src/lib/Schema/Domain/Content/Worker/Language/AddLanguageToEnum.php
@@ -16,7 +16,7 @@ class AddLanguageToEnum implements Worker, Initializer
 {
     public const ENUM_NAME = 'RepositoryLanguage';
 
-    public function init(Builder $schema)
+    public function init(Builder $schema): void
     {
         $schema->addType(
             new Builder\Input\Type(
@@ -29,7 +29,7 @@ class AddLanguageToEnum implements Worker, Initializer
     /**
      * Does the work on $schema.
      */
-    public function work(Builder $schema, array $args)
+    public function work(Builder $schema, array $args): void
     {
         /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Language $language */
         $language = $args['Language'];
@@ -52,7 +52,7 @@ class AddLanguageToEnum implements Worker, Initializer
      *
      * @return bool
      */
-    public function canWork(Builder $schema, array $args)
+    public function canWork(Builder $schema, array $args): bool
     {
         return isset($args['Language']) && $args['Language'] instanceof Language;
     }

--- a/src/lib/Schema/Domain/ImageVariationDomain.php
+++ b/src/lib/Schema/Domain/ImageVariationDomain.php
@@ -11,21 +11,18 @@ use Generator;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\GraphQL\Schema;
 use Ibexa\GraphQL\Schema\Builder;
-use Ibexa\GraphQL\Schema\Domain;
 
 /**
  * Adds configured image variations to the ImageVariationIdentifier type.
  */
-class ImageVariationDomain implements Domain\Iterator, Schema\Worker
+class ImageVariationDomain implements Iterator, Schema\Worker
 {
     public const TYPE = 'ImageVariationIdentifier';
     public const ARG = 'ImageVariation';
 
-    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
-    private $configResolver;
+    private ConfigResolverInterface $configResolver;
 
-    /** @var \Ibexa\GraphQL\Schema\Domain\NameValidator */
-    private $nameValidator;
+    private NameValidator $nameValidator;
 
     public function __construct(
         ConfigResolverInterface $configResolver,
@@ -48,12 +45,12 @@ class ImageVariationDomain implements Domain\Iterator, Schema\Worker
         }
     }
 
-    public function init(Builder $schema)
+    public function init(Builder $schema): void
     {
         $schema->addType(new Builder\Input\Type(self::TYPE, 'enum'));
     }
 
-    public function work(Builder $schema, array $args)
+    public function work(Builder $schema, array $args): void
     {
         $schema->addValueToEnum(
             self::TYPE,
@@ -61,7 +58,7 @@ class ImageVariationDomain implements Domain\Iterator, Schema\Worker
         );
     }
 
-    public function canWork(Builder $schema, array $args)
+    public function canWork(Builder $schema, array $args): bool
     {
         return isset($args[self::ARG]['identifier']);
     }

--- a/src/lib/Schema/Domain/Iterator.php
+++ b/src/lib/Schema/Domain/Iterator.php
@@ -17,10 +17,8 @@ interface Iterator
 {
     /**
      * Performs one-time initializations on the schema.
-     *
-     * @return
      */
-    public function init(Builder $schema);
+    public function init(Builder $schema): void;
 
     /**
      * Returns set of items from the domain.

--- a/src/lib/Schema/Generator.php
+++ b/src/lib/Schema/Generator.php
@@ -9,10 +9,7 @@ namespace Ibexa\GraphQL\Schema;
 
 class Generator
 {
-    /**
-     * @var Builder
-     */
-    private $schema;
+    private Builder $schema;
 
     /**
      * Grouping of schema types for writing to disk (group => [types]).
@@ -24,12 +21,12 @@ class Generator
     /**
      * @var Domain\Iterator[]
      */
-    private $iterators;
+    private array $iterators;
 
     /**
      * @var Worker[]
      */
-    private $workers;
+    private array $workers;
 
     public function __construct(Builder $schema, array $iterators, array $workers)
     {
@@ -41,7 +38,7 @@ class Generator
     /**
      * @return array
      */
-    public function generate()
+    public function generate(): array
     {
         foreach ($this->workers as $worker) {
             if ($worker instanceof Initializer) {

--- a/src/lib/Schema/SchemaGenerator.php
+++ b/src/lib/Schema/SchemaGenerator.php
@@ -12,7 +12,7 @@ class SchemaGenerator
     /**
      * @var SchemaBuilder[]
      */
-    private $schemaBuilders;
+    private array $schemaBuilders;
 
     public function __construct(array $schemaBuilders = [])
     {
@@ -22,7 +22,7 @@ class SchemaGenerator
     /**
      * @return array
      */
-    public function generate()
+    public function generate(): array
     {
         $schema = [];
         foreach ($this->schemaBuilders as $builder) {

--- a/src/lib/Value/Field.php
+++ b/src/lib/Value/Field.php
@@ -28,7 +28,7 @@ class Field extends ApiValues\Content\Field
         return (string)$this->value;
     }
 
-    public static function fromField(?ApiValues\Content\Field $field)
+    public static function fromField(?ApiValues\Content\Field $field): ?Field
     {
         return $field === null ? $field : new self(get_object_vars($field));
     }

--- a/src/lib/Value/Item.php
+++ b/src/lib/Value/Item.php
@@ -28,14 +28,12 @@ class Item
     /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Location */
     private $location;
 
-    /** @var \Ibexa\GraphQL\Resolver\LocationGuesser\LocationGuesser */
-    private $locationGuesser;
+    private LocationGuesser $locationGuesser;
 
     /** @var \Ibexa\Core\MVC\Symfony\SiteAccess */
     private $siteaccess;
 
-    /** @var \Ibexa\GraphQL\Resolver\SiteaccessGuesser\SiteaccessGuesser */
-    private $siteaccessGuesser;
+    private SiteaccessGuesser $siteaccessGuesser;
 
     private function __construct(LocationGuesser $locationGuesser, SiteaccessGuesser $siteaccessGuesser, ?Location $location = null, ?Content $content = null)
     {


### PR DESCRIPTION
> [!CAUTION]
> These changes are volatile and - in some repositories - extensive, so they need to be carefully reviewed before merging.

| :ticket: Issue | IBX-9727 |
|----------------|-----------|

#### Description:

Added missing strict type hints using `\Rector\Set\ValueObject\SetList::TYPE_DECLARATION` set.
Additionally FQCNs have been imported for every affected file using PHP CS Fixer, in some cases they might override unrelated lines.

PHPStan bump is required due to requirements of Ibexa Rector and Rector itself.

#### For QA:

Regression tests.
