### PR TITLE
IBX-9968: Resolved Symfony 7.x deprecations

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -22,4 +22,7 @@ return RectorConfig::configure()
         SymfonySetList::SYMFONY_62,
         SymfonySetList::SYMFONY_63,
         SymfonySetList::SYMFONY_64,
+        SymfonySetList::SYMFONY_70,
+        SymfonySetList::SYMFONY_71,
+        SymfonySetList::SYMFONY_72,
     ]);

--- a/src/bundle/DependencyInjection/IbexaGraphQLExtension.php
+++ b/src/bundle/DependencyInjection/IbexaGraphQLExtension.php
@@ -10,9 +10,9 @@ namespace Ibexa\Bundle\GraphQL\DependencyInjection;
 use Ibexa\Bundle\GraphQL\DependencyInjection\GraphQL\YamlSchemaProvider;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Yaml\Yaml;
 
 /**


### PR DESCRIPTION
| :ticket: Issue | IBX-9968  |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Enabled Rector Symfony 7.0, 7.1 and 7.2 sets. Resolved the following deprecations:

```
[symfony/http-kernel] Replaced usage of internal Symfony\Component\HttpKernel\DependencyInjection\Extension class
```

#### For QA:

Sanities.

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
