### PR TITLE
Added return type and improve formatting in UploadMap map method

### DIFF
--- a/src/lib/Resolver/Map/UploadMap.php
+++ b/src/lib/Resolver/Map/UploadMap.php
@@ -12,10 +12,15 @@ use Overblog\GraphQLBundle\Upload\Type\GraphQLUploadType;
 
 class UploadMap extends ResolverMap
 {
-    protected function map()
+    /**
+     * @return array<string, array<string, callable(): \Overblog\GraphQLBundle\Upload\Type\GraphQLUploadType>>
+     */
+    protected function map(): array
     {
         return [
-            'FileUpload' => [self::SCALAR_TYPE => static function (): GraphQLUploadType { return new GraphQLUploadType(); }],
+            'FileUpload' => [
+                self::SCALAR_TYPE => static fn (): GraphQLUploadType => new GraphQLUploadType(),
+            ],
         ];
     }
 }


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----|

#### Description:
Add precise PHPDoc with iterable value types to UploadMap::map() method

Added detailed return type annotation for the map() method in UploadMap class to specify array key and callable value types.

This improves static analysis by PHPStan and removes the "missing value type in iterable" warning.

No functional changes, only type safety and code clarity improvements.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
