### PR TITLE
Fixed dev-stability resolution for ibexa/design-system-twig

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "ibexa/code-style": "~2.0.0",
         "ibexa/content-forms": "~6.0.x-dev",
         "ibexa/design-engine": "~6.0.x-dev",
+        "ibexa/design-system-twig": "~6.0.x-dev",
         "ibexa/doctrine-schema": "~6.0.x-dev",
         "ibexa/http-cache": "~6.0.x-dev",
         "ibexa/notifications": "~6.0.x-dev",


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Implemented the same fix as in https://github.com/ibexa/system-info/pull/88

> ibexa/admin-ui (required in require-dev) transitively requires ibexa/design-system-twig ~6.0.x-dev, a dev-only package with no stable release yet.
> 
> This repo has no minimum-stability/prefer-stable setting (defaults to stable), so resolving composer.json directly in this repo fails with a "does not match your minimum-stability" error.
> 
> Composer only enforces minimum-stability against transitive dependencies, not explicit direct root requirements for a dev branch — so adding it directly to require-dev at ~6.0.x-dev (same convention as every other entry in this file) is enough on its own.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
